### PR TITLE
more trimming

### DIFF
--- a/samples/trimming/README.md
+++ b/samples/trimming/README.md
@@ -8,4 +8,4 @@ To test and measure build size:
 
 | .NET  | Raw   | Brotli |
 |-------|-------|--------|
-| 8.0.1 | 2,317 | 744    |
+| 8.0.1 | 2,298 | 739    |

--- a/src/cs/Bootsharp/Build/Bootsharp.targets
+++ b/src/cs/Bootsharp/Build/Bootsharp.targets
@@ -16,6 +16,7 @@
             <PropertyGroup>
                 <!-- https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?#minimize-app-download-size -->
                 <!-- https://raw.githubusercontent.com/dotnet/runtime/main/docs/workflow/trimming/feature-switches.md -->
+                <!-- https://github.com/dotnet/runtime/issues/94805 -->
                 <PublishTrimmed>true</PublishTrimmed>
                 <TrimMode>full</TrimMode>
                 <TrimmerRemoveSymbols>true</TrimmerRemoveSymbols>

--- a/src/cs/Bootsharp/Build/Bootsharp.targets
+++ b/src/cs/Bootsharp/Build/Bootsharp.targets
@@ -38,6 +38,11 @@
                 <WasmEmitSourceMap>false</WasmEmitSourceMap>
                 <WasmNativeDebugSymbols>false</WasmNativeDebugSymbols>
                 <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+                <PredefinedCulturesOnly>true</PredefinedCulturesOnly>
+                <MetricsSupport>false</MetricsSupport>
+                <DisableDependencyInjectionDynamicEngine>true</DisableDependencyInjectionDynamicEngine>
+                <NullabilityInfoContextSupport>false</NullabilityInfoContextSupport>
+                <DynamicCodeSupport>false</DynamicCodeSupport>
             </PropertyGroup>
         </When>
     </Choose>

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>


### PR DESCRIPTION
Disabled more non-essential .NET features when `BootsharpAggressiveTrimming` is enabled to further shrink binary size.