### PR TITLE
fix: error on duplicate serialized types

### DIFF
--- a/src/cs/Bootsharp.Publish.Test/Emit/SerializerTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/Emit/SerializerTest.cs
@@ -23,7 +23,53 @@ public class SerializerTest : EmitTest
     }
 
     [Fact]
-    public void DoesntSerializeInstancedInteropInterfaces ()
+    public void SerializesTypesFromInteropMethods ()
+    {
+        AddAssembly(With(
+            """
+            public record RecordA;
+            public record RecordB;
+            public record RecordC;
+
+            public class Class
+            {
+                [JSInvokable] public static Task<RecordA[]> A (RecordC c) => default;
+                [JSFunction] public static RecordB[] B (RecordC[] c) => default;
+            }
+            """));
+        Execute();
+        Contains("[JsonSerializable(typeof(global::RecordA)");
+        Contains("[JsonSerializable(typeof(global::RecordB)");
+        Contains("[JsonSerializable(typeof(global::RecordC)");
+        Contains("[JsonSerializable(typeof(global::RecordA[])");
+        Contains("[JsonSerializable(typeof(global::RecordB[])");
+        Contains("[JsonSerializable(typeof(global::RecordC[])");
+    }
+
+    [Fact]
+    public void SerializesTypesFromInteropInterfaces ()
+    {
+        AddAssembly(With(
+            """
+            public record RecordA;
+            public record RecordB;
+            public record RecordC;
+            public interface IExported { void Inv (RecordA a); }
+            public interface IImported { void Fun (RecordB b); void NotifyEvt(RecordC c); }
+
+            public class Class
+            {
+                [JSFunction] public static Task<IImported> GetImported (IExported arg) => default;
+            }
+            """));
+        Execute();
+        Contains("[JsonSerializable(typeof(global::RecordA)");
+        Contains("[JsonSerializable(typeof(global::RecordB)");
+        Contains("[JsonSerializable(typeof(global::RecordC)");
+    }
+
+    [Fact]
+    public void DoesntSerializeInstancedInteropInterfacesThemselves ()
     {
         AddAssembly(With(
             """
@@ -46,23 +92,32 @@ public class SerializerTest : EmitTest
         DoesNotContain("JsonSerializable");
     }
 
-    [Fact] // .NET's generator indexes types by short names (w/o namespace) and fails on duplicates.
-    public void AddsOnlyTopLevelTypesAndCrawledDuplicates ()
+    [Fact]
+    public void SerializesAllTheCrawledSerializableTypes ()
     {
+        // .NET's generator indexes types by short names (w/o namespace) and fails on duplicates, so we have to add everything ourselves.
+        // https://github.com/dotnet/runtime/issues/58938#issuecomment-1306731801
         AddAssembly(
-            With("y", "public struct Struct { public double A { get; set; } }"),
-            With("n", "public struct Struct { public y.Struct S { get; set; } }"),
+            With("y", "public enum Enum { A, B }"),
+            With("y", "public record Struct (double A, ReadonlyStruct[]? B);"),
+            With("y", "public record ReadonlyStruct (Enum e);"),
+            With("n", "public struct Struct { public y.Struct S { get; set; } public ReadonlyStruct[]? A { get; set; } }"),
             With("n", "public readonly struct ReadonlyStruct { public double A { get; init; } }"),
             With("n", "public readonly record struct ReadonlyRecordStruct(double A);"),
             With("n", "public record class RecordClass(double A);"),
             With("n", "public enum Enum { A, B }"),
             With("n", "public class Foo { public Struct S { get; } public ReadonlyStruct Rs { get; } }"),
             WithClass("n", "public class Bar : Foo { public ReadonlyRecordStruct Rrs { get; } public RecordClass Rc { get; } }"),
-            With("n", "public class Baz { public List<Class.Bar?> Bars { get; } public Enum E { get; } }"),
-            WithClass("n", "[JSInvokable] public static Task<Baz?> GetBaz () => default;"));
+            With("n", "public class Baz { public List<Class.Bar?> Bars { get; } }"),
+            WithClass("n", "[JSInvokable] public static Task<Baz?> GetBaz (Enum e) => default;"));
         Execute();
-        Assert.Equal(2, Matches("JsonSerializable").Count);
-        Contains("[JsonSerializable(typeof(global::n.Baz)");
+        Contains("[JsonSerializable(typeof(global::y.Enum)");
+        Contains("[JsonSerializable(typeof(global::n.Enum)");
         Contains("[JsonSerializable(typeof(global::y.Struct)");
+        Contains("[JsonSerializable(typeof(global::n.Struct)");
+        Contains("[JsonSerializable(typeof(global::n.ReadonlyStruct)");
+        Contains("[JsonSerializable(typeof(global::y.ReadonlyStruct)");
+        Contains("[JsonSerializable(typeof(global::n.ReadonlyStruct[])");
+        Contains("[JsonSerializable(typeof(global::y.ReadonlyStruct[])");
     }
 }

--- a/src/cs/Bootsharp.Publish/Common/TypeConverter/TypeCrawler.cs
+++ b/src/cs/Bootsharp.Publish/Common/TypeConverter/TypeCrawler.cs
@@ -9,10 +9,11 @@ internal sealed class TypeCrawler
     public void Crawl (Type type)
     {
         if (!ShouldCrawl(type)) return;
-        type = GetUnderlyingType(type);
-        if (!crawled.Add(type)) return;
-        CrawlProperties(type);
-        CrawlBaseType(type);
+        var underlyingType = GetUnderlyingType(type);
+        if (!crawled.Add(underlyingType)) return;
+        CrawlProperties(underlyingType);
+        CrawlBaseType(underlyingType);
+        crawled.Add(type);
     }
 
     private bool ShouldCrawl (Type type)

--- a/src/cs/Bootsharp.Publish/Emit/SerializerGenerator.cs
+++ b/src/cs/Bootsharp.Publish/Emit/SerializerGenerator.cs
@@ -11,8 +11,8 @@ internal sealed class SerializerGenerator
 
     public string Generate (SolutionInspection inspection)
     {
-        CollectAttributes(inspection);
-        CollectDuplicates(inspection);
+        CollectTopLevel(inspection);
+        CollectCrawled(inspection);
         if (attributes.Count == 0) return "";
         return
             $"""
@@ -30,7 +30,7 @@ internal sealed class SerializerGenerator
              """;
     }
 
-    private void CollectAttributes (SolutionInspection inspection)
+    private void CollectTopLevel (SolutionInspection inspection)
     {
         var metas = inspection.StaticMethods
             .Concat(inspection.StaticInterfaces.SelectMany(i => i.Methods))
@@ -53,11 +53,10 @@ internal sealed class SerializerGenerator
         attributes.Add(BuildAttribute(meta.Type));
     }
 
-    private void CollectDuplicates (SolutionInspection inspection)
+    private void CollectCrawled (SolutionInspection inspection)
     {
-        var names = new HashSet<string>();
-        foreach (var type in inspection.Crawled.DistinctBy(t => t.FullName))
-            if (ShouldSerialize(type) && !names.Add(type.Name))
+        foreach (var type in inspection.Crawled)
+            if (ShouldSerialize(type))
                 attributes.Add(BuildAttribute(type));
     }
 

--- a/src/cs/Bootsharp.Publish/Pack/DeclarationGenerator/TypeDeclarationGenerator.cs
+++ b/src/cs/Bootsharp.Publish/Pack/DeclarationGenerator/TypeDeclarationGenerator.cs
@@ -20,7 +20,7 @@ internal sealed class TypeDeclarationGenerator (Preferences prefs)
     public string Generate (SolutionInspection inspection)
     {
         instanced = [..inspection.InstancedInterfaces];
-        types = inspection.Crawled.OrderBy(GetNamespace).ToArray();
+        types = inspection.Crawled.Where(FilterCrawled).OrderBy(GetNamespace).ToArray();
         for (index = 0; index < types.Length; index++)
             DeclareType();
         return builder.ToString();
@@ -30,6 +30,11 @@ internal sealed class TypeDeclarationGenerator (Preferences prefs)
     {
         var type = types[index];
         return type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+    }
+
+    private bool FilterCrawled (Type type)
+    {
+        return !IsList(type) && !IsCollection(type) && !IsNullable(type);
     }
 
     private void DeclareType ()

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.1</Version>
+        <Version>0.6.2</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>


### PR DESCRIPTION
We have to explicitly specify all the serialized types passing interop boundary due to .NET's design flaw, where it's indexing the types just by their short name, instead of using the full name.  https://github.com/dotnet/runtime/issues/58938#issuecomment-1306731801

