### PR TITLE
feat: add binaryen opt

### DIFF
--- a/docs/guide/build-config.md
+++ b/docs/guide/build-config.md
@@ -2,19 +2,20 @@
 
 Build and publish related options are configured in `.csproj` file via MSBuild properties.
 
-| Property                    | Default    | Description                                                  |
-|-----------------------------|------------|--------------------------------------------------------------|
-| BootsharpName               | bootsharp  | Name of the generated JavaScript module.                     |
-| BootsharpEmbedBinaries      | true       | Whether to embed binaries to the JavaScript module file.     |
-| BootsharpAggressiveTrimming | false      | Whether to disable some .NET features to reduce binary size. |
-| BootsharpLLVM               | false      | Enable experimental [NativeAOT-LLVM](/guide/llvm) backend.   |
-| BootsharpBundleCommand      | npx rollup | The command to bundle generated JavaScrip solution.          |
-| BootsharpPublishDirectory   | /bin       | Directory to publish generated JavaScript module.            |
-| BootsharpTypesDirectory     | /types     | Directory to publish type declarations.                      |
-| BootsharpBinariesDirectory  | /bin       | Directory to publish binaries when `EmbedBinaries` disabled. |
-| BootsharpPackageDirectory   | /          | Directory to publish `package.json` file.                    |
+| Property                    | Default    | Description                                                                                                                      |
+|-----------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------|
+| BootsharpName               | bootsharp  | Name of the generated JavaScript module.                                                                                         |
+| BootsharpEmbedBinaries      | true       | Whether to embed binaries to the JavaScript module file.                                                                         |
+| BootsharpAggressiveTrimming | false      | Whether to disable some .NET features to reduce binary size.                                                                     |
+| BootsharpOptimize           | none       | Whether to optimize the WASM for `speed` or `size`. Requires [Binaryen](https://github.com/WebAssembly/binaryen) in system path. |
+| BootsharpLLVM               | false      | Enable experimental [NativeAOT-LLVM](/guide/llvm) backend.                                                                       |
+| BootsharpBundleCommand      | npx rollup | The command to bundle generated JavaScrip solution.                                                                              |
+| BootsharpPublishDirectory   | /bin       | Directory to publish generated JavaScript module.                                                                                |
+| BootsharpTypesDirectory     | /types     | Directory to publish type declarations.                                                                                          |
+| BootsharpBinariesDirectory  | /bin       | Directory to publish binaries when `EmbedBinaries` disabled.                                                                     |
+| BootsharpPackageDirectory   | /          | Directory to publish `package.json` file.                                                                                        |
 
-Below is an example configuration, which will make Bootsharp name compiled module "backend" (instead of the default "bootsharp"), publish the module under solution directory root (instead of "/bin"), disable binaries embedding and instead publish them under "public/bin" directory one level above the solution root and enable aggressive assembly trimming to reduce build size:
+Below is an example configuration, which will make Bootsharp name compiled module "backend" (instead of the default "bootsharp"), publish the module under solution directory root (instead of "/bin"), disable binaries embedding and instead publish them under "public/bin" directory one level above the solution root and enable aggressive assembly trimming and WASM optimization to reduce the build size:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -27,6 +28,7 @@ Below is an example configuration, which will make Bootsharp name compiled modul
         <BootsharpEmbedBinaries>false</BootsharpEmbedBinaries>
         <BootsharpBinariesDirectory>$(SolutionDir)../public/bin</BootsharpBinariesDirectory>
         <BootsharpAggressiveTrimming>true</BootsharpAggressiveTrimming>
+        <BootsharpOptimize>size</BootsharpOptimize>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/guide/llvm.md
+++ b/docs/guide/llvm.md
@@ -58,8 +58,8 @@ Use following `.csproj` as a reference for enabling NativeAOT-LLVM with Bootshar
 
 ## Binaryen
 
-Optionally, after publishing with NativeAOT-LLVM, you can further optimize the produced WASM using Binaryen:
+Optionally, you can further optimize the produced WASM using Binaryen:
 
 1. Install the tool https://github.com/WebAssembly/binaryen
-2. Run `wasm-opt bin/bootsharp/bin/dotnet.native.wasm -O3 -o bin/bootsharp/bin/dotnet.native.wasm --all-features --strip-dwarf --strip-debug --vacuum`
-3. To optimize for size instead of speed, replace `-O3` with `-Oz`
+2. Make sure `wasm-opt` is in the system path
+3. Add `<BootsharpOptimize>speed</BootsharpOptimize>` to the project config to optimize for speed; replace `speed` with `size` to instead optimize for size

--- a/src/cs/Bootsharp/Build/Bootsharp.props
+++ b/src/cs/Bootsharp/Build/Bootsharp.props
@@ -18,6 +18,8 @@
         <BootsharpEmbedBinaries>true</BootsharpEmbedBinaries>
         <!-- Whether to disable some .NET features to reduce binary size (true or false); false by default. -->
         <BootsharpAggressiveTrimming>false</BootsharpAggressiveTrimming>
+        <!-- Whether to optimize the WASM for speed or size (requires Binaryen's wasm-opt in system path); disabled by default. -->
+        <BootsharpOptimize>none</BootsharpOptimize>
         <!-- Whether to app is built with the new experimental NativeAOT-LLVM backend; false by default. -->
         <BootsharpLLVM>false</BootsharpLLVM>
         <!-- The command to run when compiling/bundling generated JavaScrip solution. -->

--- a/src/cs/Bootsharp/Build/Bootsharp.targets
+++ b/src/cs/Bootsharp/Build/Bootsharp.targets
@@ -109,6 +109,8 @@
             <BootsharpThreading Condition="'$(WasmEnableThreads)' == 'true'">true</BootsharpThreading>
             <BootsharpThreading Condition="'$(WasmEnableThreads)' != 'true'">false</BootsharpThreading>
             <BootsharpEmbedBinaries Condition="$(BootsharpThreading)">false</BootsharpEmbedBinaries>
+            <BootsharpOptimizeFlag Condition="'$(BootsharpOptimize)' == 'speed'">-O3</BootsharpOptimizeFlag>
+            <BootsharpOptimizeFlag Condition="'$(BootsharpOptimize)' == 'size'">-Oz</BootsharpOptimizeFlag>
         </PropertyGroup>
 
         <!-- Copy bootsharp source files to the build directory. -->
@@ -116,6 +118,12 @@
             <BootsharpSourceFiles Include="$(BootsharpSourceDirectory)/*.*"/>
         </ItemGroup>
         <Copy SourceFiles="@(BootsharpSourceFiles)" DestinationFolder="$(BootsharpBuildDirectory)"/>
+
+        <!-- Optimize the dotnet WASM with Binaryen. -->
+        <Exec Condition="'$(BootsharpOptimize)' != 'none'"
+              Command="wasm-opt dotnet.native.wasm $(BootsharpOptimizeFlag) -o dotnet.native.wasm --all-features --strip-dwarf --strip-debug --vacuum"
+              WorkingDirectory="$(BootsharpBuildDirectory)"
+              StdOutEncoding="utf-8" StdErrEncoding="utf-8"/>
 
         <!-- Generate bindings, type declarations and (optionally) embed binaries. -->
         <BootsharpPack BuildDirectory="$(BootsharpBuildDirectory)"

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.6.2</Version>
+        <Version>0.6.3</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>


### PR DESCRIPTION
This adds an option to optimize the WASM with [Binaryen](https://github.com/WebAssembly/binaryen) via project config props:

- `<BootsharpOptimize>size</BootsharpOptimize>` for size
- `<BootsharpOptimize>speed</BootsharpOptimize>` for speed 

Binaryen's `wasm-opt` has to be in system path.