### PR TITLE
feat: support visual studio build host

### DIFF
--- a/src/cs/Bootsharp/Build/Bootsharp.targets
+++ b/src/cs/Bootsharp/Build/Bootsharp.targets
@@ -39,8 +39,18 @@
         <EmscriptenEnvVars Include="EM_CACHE=$(EmscriptenCacheSdkCacheDir)"/>
     </ItemGroup>
 
-    <UsingTask TaskName="Bootsharp.Publish.BootsharpEmit" AssemblyFile="$(BootsharpPublishAssembly)"/>
-    <UsingTask TaskName="Bootsharp.Publish.BootsharpPack" AssemblyFile="$(BootsharpPublishAssembly)"/>
+    <!-- Register tasks for Visual Studio. (https://github.com/elringus/bootsharp/issues/137) -->
+    <UsingTask Condition="'$(MSBuildRuntimeType)' == 'Full'"
+               TaskName="Bootsharp.Publish.BootsharpEmit" AssemblyFile="$(BootsharpPublishAssembly)"
+               Runtime="NET" TaskFactory="TaskHostFactory"/>
+    <UsingTask Condition="'$(MSBuildRuntimeType)' == 'Full'"
+               TaskName="Bootsharp.Publish.BootsharpPack" AssemblyFile="$(BootsharpPublishAssembly)"
+               Runtime="NET" TaskFactory="TaskHostFactory"/>
+    <!-- Register tasks for 'dotnet publish' run from CLI. -->
+    <UsingTask Condition="'$(MSBuildRuntimeType)' != 'Full'"
+               TaskName="Bootsharp.Publish.BootsharpEmit" AssemblyFile="$(BootsharpPublishAssembly)"/>
+    <UsingTask Condition="'$(MSBuildRuntimeType)' != 'Full'"
+               TaskName="Bootsharp.Publish.BootsharpPack" AssemblyFile="$(BootsharpPublishAssembly)"/>
 
     <!-- A hack due to source generator compositing not possible. (https://github.com/dotnet/roslyn/issues/57239#issuecomment-1585235740) -->
     <Target Name="BootsharpEmit" BeforeTargets="GenerateAdditionalSources"

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.0-alpha.44</Version>
+        <Version>0.8.0-alpha.45</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>


### PR DESCRIPTION
Fixes #137.

https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/sdk#use-net-msbuild-tasks-with-net-framework-msbuild

We used conditionals, so that normal CLI builds would still use the default in-process build runtime for better performance.