### PR TITLE
feat!: use .net 10 runtime config

### DIFF
--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.0-alpha.45</Version>
+        <Version>0.8.0-alpha.46</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>

--- a/src/js/scripts/compile-test.sh
+++ b/src/js/scripts/compile-test.sh
@@ -1,4 +1,6 @@
 cd test/cs
+rm -rf Test/bin Test/obj Test.Types/bin Test.Types/obj
 dotnet restore --no-cache --force-evaluate
 dotnet publish -p BootsharpName=embedded -p BootsharpEmbedBinaries=true -c Debug
+rm -rf Test/bin/Debug Test/obj Test.Types/bin Test.Types/obj
 dotnet publish -p BootsharpName=sideload -p BootsharpEmbedBinaries=false -c Debug

--- a/src/js/src/config.ts
+++ b/src/js/src/config.ts
@@ -1,4 +1,4 @@
-import { RuntimeConfig, AssetEntry, AssetBehaviors, getRuntime, getNative, getMain } from "./modules";
+import { RuntimeConfig, RuntimeWasm, RuntimeModule, RuntimeAssembly, getRuntime, getNative } from "./modules";
 import { BinaryResource, BootResources } from "./resources";
 import { decodeBase64 } from "./decoder";
 
@@ -7,39 +7,43 @@ import { decodeBase64 } from "./decoder";
  *  @param root When specified, assumes boot resources are side-loaded from the specified root. */
 export async function buildConfig(resources: BootResources, root?: string): Promise<RuntimeConfig> {
     const embed = root == null;
-    const assets: AssetEntry[] = await Promise.all([
-        resolveWasm(),
-        resolveModule("dotnet.js", "js-module-dotnet", embed ? getMain : undefined),
-        resolveModule("dotnet.native.js", "js-module-native", embed ? getNative : undefined),
-        resolveModule("dotnet.runtime.js", "js-module-runtime", embed ? getRuntime : undefined),
-        ...resources.assemblies.map(resolveAssembly)
-    ]);
     const mt = !embed && (await import("./dotnet.g")).mt;
-    if (mt) assets.push(await resolveModule("dotnet.native.worker.mjs", "js-module-threads"));
-    return { assets, mainAssemblyName: resources.entryAssemblyName };
+    const [wasm, native, runtime, assemblies] = await Promise.all([
+        resolveWasm(),
+        resolveModule("dotnet.native.js", embed ? getNative : undefined),
+        resolveModule("dotnet.runtime.js", embed ? getRuntime : undefined),
+        Promise.all(resources.assemblies.map(resolveAssembly))
+    ]);
+    return {
+        resources: {
+            wasmNative: [wasm],
+            jsModuleNative: [native],
+            jsModuleRuntime: [runtime],
+            jsModuleWorker: mt ? [await resolveModule("dotnet.native.worker.mjs")] : undefined,
+            assembly: assemblies
+        },
+        mainAssemblyName: resources.entryAssemblyName
+    };
 
-    async function resolveWasm(): Promise<AssetEntry> {
+    async function resolveWasm(): Promise<RuntimeWasm> {
         return {
             name: resources.wasm.name,
-            buffer: await resolveBuffer(resources.wasm),
-            behavior: "dotnetwasm"
+            buffer: await resolveBuffer(resources.wasm)
         };
     }
 
-    async function resolveModule(name: string, behavior: AssetBehaviors,
-        embed?: () => Promise<unknown>): Promise<AssetEntry> {
+    async function resolveModule(name: string, embed?: () => Promise<unknown>): Promise<RuntimeModule> {
         return {
             name,
-            moduleExports: embed ? await embed() : undefined,
-            behavior
+            moduleExports: embed ? await embed() : undefined
         };
     }
 
-    async function resolveAssembly(res: BinaryResource): Promise<AssetEntry> {
+    async function resolveAssembly(res: BinaryResource): Promise<RuntimeAssembly> {
         return {
             name: res.name,
-            buffer: await resolveBuffer(res),
-            behavior: "assembly"
+            virtualPath: res.name,
+            buffer: await resolveBuffer(res)
         };
     }
 

--- a/src/js/src/dotnet.g.d.ts
+++ b/src/js/src/dotnet.g.d.ts
@@ -2,7 +2,7 @@
 export const embedded = false;
 export const mt = false;
 
-// Types: https://github.com/dotnet/runtime/blob/v9.0.0/src/mono/browser/runtime/dotnet.d.ts
+// Types: https://github.com/dotnet/runtime/blob/release/10.0/src/mono/browser/runtime/dotnet.d.ts
 
 declare interface NativePointer {
     __brandNativePointer: "NativePointer";
@@ -57,11 +57,11 @@ declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Arra
 interface DotnetHostBuilder {
     /**
      * @param config default values for the runtime configuration. It will be merged with the default values.
-     * Note that if you provide resources and don't provide custom configSrc URL, the blazor.boot.json will be downloaded and applied by default.
+     * Note that if you provide resources and don't provide custom configSrc URL, the dotnet.boot.js will be downloaded and applied by default.
      */
     withConfig(config: MonoConfig): DotnetHostBuilder;
     /**
-     * @param configSrc URL to the configuration file. ./blazor.boot.json is a default config file location.
+     * @param configSrc URL to the configuration file. ./dotnet.boot.js is a default config file location.
      */
     withConfigSrc(configSrc: string): DotnetHostBuilder;
     /**
@@ -166,14 +166,6 @@ type MonoConfig = {
      */
     debugLevel?: number;
     /**
-     * Gets a value that determines whether to enable caching of the 'resources' inside a CacheStorage instance within the browser.
-     */
-    cacheBootResources?: boolean;
-    /**
-     * Delay of the purge of the cached resources in milliseconds. Default is 10000 (10 seconds).
-     */
-    cachedResourcesPurgeDelay?: number;
-    /**
      * Configures use of the `integrity` directive for fetching assets
      */
     disableIntegrityCheck?: boolean;
@@ -190,6 +182,16 @@ type MonoConfig = {
      */
     environmentVariables?: {
         [i: string]: string;
+    };
+    /**
+     * Subset of runtimeconfig.json
+     */
+    runtimeConfig?: {
+        runtimeOptions?: {
+            configProperties?: {
+                [i: string]: string | number | boolean;
+            };
+        };
     };
     /**
      * initial number of workers to add to the emscripten pthread pool
@@ -217,10 +219,7 @@ type MonoConfig = {
      * Gets the application culture. This is a name specified in the BCP 47 format. See https://tools.ietf.org/html/bcp47
      */
     applicationCulture?: string;
-    /**
-     * definition of assets to load along with the runtime.
-     */
-    resources?: ResourceGroups;
+    resources?: Assets;
     /**
      * appsettings files to load to VFS
      */
@@ -244,36 +243,90 @@ type MonoConfig = {
 type ResourceExtensions = {
     [extensionName: string]: ResourceList;
 };
-interface ResourceGroups {
+interface Assets {
     hash?: string;
-    fingerprinting?: {
-        [name: string]: string;
-    };
-    coreAssembly?: ResourceList;
-    assembly?: ResourceList;
-    lazyAssembly?: ResourceList;
-    corePdb?: ResourceList;
-    pdb?: ResourceList;
-    jsModuleWorker?: ResourceList;
-    jsModuleGlobalization?: ResourceList;
-    jsModuleNative: ResourceList;
-    jsModuleRuntime: ResourceList;
-    wasmSymbols?: ResourceList;
-    wasmNative: ResourceList;
-    icu?: ResourceList;
+    coreAssembly?: AssemblyAsset[];
+    assembly?: AssemblyAsset[];
+    lazyAssembly?: AssemblyAsset[];
+    corePdb?: PdbAsset[];
+    pdb?: PdbAsset[];
+    jsModuleWorker?: JsAsset[];
+    jsModuleDiagnostics?: JsAsset[];
+    jsModuleNative: JsAsset[];
+    jsModuleRuntime: JsAsset[];
+    wasmSymbols?: SymbolsAsset[];
+    wasmNative: WasmAsset[];
+    icu?: IcuAsset[];
     satelliteResources?: {
-        [cultureName: string]: ResourceList;
+        [cultureName: string]: AssemblyAsset[];
     };
-    modulesAfterConfigLoaded?: ResourceList;
-    modulesAfterRuntimeReady?: ResourceList;
+    modulesAfterConfigLoaded?: JsAsset[];
+    modulesAfterRuntimeReady?: JsAsset[];
     extensions?: ResourceExtensions;
-    coreVfs?: {
-        [virtualPath: string]: ResourceList;
-    };
-    vfs?: {
-        [virtualPath: string]: ResourceList;
-    };
+    coreVfs?: VfsAsset[];
+    vfs?: VfsAsset[];
 }
+type Asset = {
+    /**
+     * this should be absolute url to the asset
+     */
+    resolvedUrl?: string;
+    /**
+     * If true, the runtime startup would not fail if the asset download was not successful.
+     */
+    isOptional?: boolean;
+    /**
+     * If provided, runtime doesn't have to fetch the data.
+     * Runtime would set the buffer to null after instantiation to free the memory.
+     */
+    buffer?: ArrayBuffer | Promise<ArrayBuffer>;
+    /**
+     * It's metadata + fetch-like Promise<Response>
+     * If provided, the runtime doesn't have to initiate the download. It would just await the response.
+     */
+    pendingDownload?: LoadingResource;
+};
+type WasmAsset = Asset & {
+    name: string;
+    hash?: string | null | "";
+    cache?: RequestCache;
+};
+type AssemblyAsset = Asset & {
+    virtualPath: string;
+    name: string;
+    hash?: string | null | "";
+    cache?: RequestCache;
+};
+type PdbAsset = Asset & {
+    virtualPath: string;
+    name: string;
+    hash?: string | null | "";
+    cache?: RequestCache;
+};
+type JsAsset = Asset & {
+    /**
+     * If provided, runtime doesn't have to import it's JavaScript modules.
+     * This will not work for multi-threaded runtime.
+     */
+    moduleExports?: any | Promise<any>;
+    name?: string;
+};
+type SymbolsAsset = Asset & {
+    name: string;
+    cache?: RequestCache;
+};
+type VfsAsset = Asset & {
+    virtualPath: string;
+    name: string;
+    hash?: string | null | "";
+    cache?: RequestCache;
+};
+type IcuAsset = Asset & {
+    virtualPath: string;
+    name: string;
+    hash?: string | null | "";
+    cache?: RequestCache;
+};
 /**
  * A "key" is name of the file, a "value" is optional hash for integrity check.
  */
@@ -291,7 +344,10 @@ type ResourceList = {
  * @returns A URI string or a Response promise to override the loading process, or null/undefined to allow the default loading behavior.
  * When returned string is not qualified with `./` or absolute URL, it will be resolved against the application base URI.
  */
-type LoadBootResourceCallback = (type: WebAssemblyBootResourceType, name: string, defaultUri: string, integrity: string, behavior: AssetBehaviors) => string | Promise<Response> | null | undefined;
+type LoadBootResourceCallback = (type: WebAssemblyBootResourceType, name: string, defaultUri: string, integrity: string, behavior: AssetBehaviors) => string | Promise<Response> | Promise<BootModule> | null | undefined;
+type BootModule = {
+    config: MonoConfig;
+};
 interface LoadingResource {
     name: string;
     url: string;
@@ -360,6 +416,10 @@ type SingleAssetBehaviors =
      */
     | "js-module-threads"
     /**
+     * The javascript module for diagnostic server and client.
+     */
+    | "js-module-diagnostics"
+    /**
      * The javascript module for runtime.
      */
     | "js-module-runtime"
@@ -368,21 +428,13 @@ type SingleAssetBehaviors =
      */
     | "js-module-native"
     /**
-     * The javascript module for hybrid globalization.
-     */
-    | "js-module-globalization"
-    /**
-     * Typically blazor.boot.json
+     * Typically dotnet.boot.js
      */
     | "manifest"
     /**
      * The debugging symbols
      */
-    | "symbols"
-    /**
-     * Load segmentation rules file for Hybrid Globalization.
-     */
-    | "segmentation-rules";
+    | "symbols";
 type AssetBehaviors = SingleAssetBehaviors |
     /**
      * Load asset as a managed resource assembly.
@@ -428,11 +480,7 @@ declare const enum GlobalizationMode {
     /**
      * Use user defined icu file.
      */
-    Custom = "custom",
-    /**
-     * Operate in hybrid globalization mode with small ICU files, using native platform functions.
-     */
-    Hybrid = "hybrid"
+    Custom = "custom"
 }
 type DotnetModuleConfig = {
     config?: MonoConfig;
@@ -443,7 +491,7 @@ type DotnetModuleConfig = {
     imports?: any;
     exports?: string[];
 } & Partial<EmscriptenModule>;
-type APIType = {
+type RunAPIType = {
     /**
      * Runs the Main() method of the application.
      * Note: this will keep the .NET runtime alive and the APIs will be available for further calls.
@@ -493,6 +541,8 @@ type APIType = {
      * You can register the scripts using MonoConfig.resources.modulesAfterConfigLoaded and MonoConfig.resources.modulesAfterRuntimeReady.
      */
     invokeLibraryInitializers: (functionName: string, args: any[]) => Promise<void>;
+};
+type MemoryAPIType = {
     /**
      * Writes to the WASM linear memory
      */
@@ -634,6 +684,43 @@ type APIType = {
      */
     localHeapViewF64: () => Float64Array;
 };
+type DiagnosticsAPIType = {
+    /**
+     * creates diagnostic trace file. Default is 60 seconds.
+     * It could be opened in PerfView or Visual Studio as is.
+     */
+    collectCpuSamples: (options?: DiagnosticCommandOptions) => Promise<Uint8Array[]>;
+    /**
+     * creates diagnostic trace file. Default is 60 seconds.
+     * It could be opened in PerfView or Visual Studio as is.
+     * It could be summarized by `dotnet-trace report xxx.nettrace topN -n 10`
+     */
+    collectMetrics: (options?: DiagnosticCommandOptions) => Promise<Uint8Array[]>;
+    /**
+     * creates diagnostic trace file.
+     * It could be opened in PerfView as is.
+     * It could be converted for Visual Studio using `dotnet-gcdump convert`.
+     */
+    collectGcDump: (options?: DiagnosticCommandOptions) => Promise<Uint8Array[]>;
+    /**
+     * changes DOTNET_DiagnosticPorts and makes a new connection to WebSocket on that URL.
+     */
+    connectDSRouter(url: string): void;
+};
+type DiagnosticCommandProviderV2 = {
+    keywords: [number, number];
+    logLevel: number;
+    provider_name: string;
+    arguments: string | null;
+};
+type DiagnosticCommandOptions = {
+    durationSeconds?: number;
+    intervalSeconds?: number;
+    skipDownload?: boolean;
+    circularBufferMB?: number;
+    extraProviders?: DiagnosticCommandProviderV2[];
+};
+type APIType = RunAPIType & MemoryAPIType & DiagnosticsAPIType;
 type RuntimeAPI = {
     INTERNAL: any;
     Module: EmscriptenModule;

--- a/src/js/src/modules.ts
+++ b/src/js/src/modules.ts
@@ -1,9 +1,13 @@
-import type { ModuleAPI, MonoConfig, AssetEntry } from "./dotnet.g.d.ts";
+import type { ModuleAPI, MonoConfig } from "./dotnet.g.d.ts";
 
 export type * from "./dotnet.g.d.ts";
-export type RuntimeConfig = MonoConfig & { assets?: AssetEntry[] };
+export type RuntimeConfig = MonoConfig;
+export type RuntimeResources = NonNullable<RuntimeConfig["resources"]>;
+export type RuntimeWasm = NonNullable<RuntimeResources["wasmNative"]>[number];
+export type RuntimeModule = NonNullable<RuntimeResources["jsModuleNative"]>[number];
+export type RuntimeAssembly = NonNullable<RuntimeResources["assembly"]>[number];
 
-/** Fetches main dotnet module (<code>dotnet.js</code>). */
+/** Fetches the main dotnet module (<code>dotnet.js</code>). */
 export async function getMain(root?: string): Promise<ModuleAPI & { embedded?: boolean }> {
     if (root == null) return await import("./dotnet.g");
     return await import(/*@vite-ignore*//*webpackIgnore:true*/`${root}/dotnet.js`);

--- a/src/js/test/spec/boot.spec.ts
+++ b/src/js/test/spec/boot.spec.ts
@@ -34,9 +34,8 @@ describe("boot", () => {
     it("defines module exports when root is not specified", async () => {
         const { embed: { bootsharp } } = await setup();
         const config = await bootsharp.dotnet.buildConfig(bootsharp.resources);
-        expect(config.assets!.find(a => a.behavior === "js-module-dotnet")!.moduleExports).toBeDefined();
-        expect(config.assets!.find(a => a.behavior === "js-module-native")!.moduleExports).toBeDefined();
-        expect(config.assets!.find(a => a.behavior === "js-module-runtime")!.moduleExports).toBeDefined();
+        expect(config.resources!.jsModuleNative[0].moduleExports).toBeDefined();
+        expect(config.resources!.jsModuleRuntime[0].moduleExports).toBeDefined();
     });
     it("throws when missing boot resource", async () => {
         const { side: { bootsharp } } = await setup();
@@ -147,31 +146,30 @@ describe("boot", () => {
         const customs: BootOptions = {
             config: {
                 mainAssemblyName: bins.entryAssemblyName,
-                assets: [
-                    {
-                        name: resolve("test/cs/Test/bin/sideload/bin/dotnet.js"),
-                        behavior: "js-module-dotnet"
-                    },
-                    {
-                        name: resolve("test/cs/Test/bin/sideload/bin/dotnet.runtime.js"),
-                        behavior: "js-module-runtime"
-                    },
-                    {
-                        name: resolve("test/cs/Test/bin/sideload/bin/dotnet.native.js"),
-                        behavior: "js-module-native"
-                    },
-                    {
+                resources: {
+                    jsModuleRuntime: [{
+                        name: "dotnet.runtime.js",
+                        resolvedUrl: resolve("test/cs/Test/bin/sideload/bin/dotnet.runtime.js")
+                    }],
+                    jsModuleNative: [{
+                        name: "dotnet.native.js",
+                        resolvedUrl: resolve("test/cs/Test/bin/sideload/bin/dotnet.native.js")
+                    }],
+                    wasmNative: [{
                         name: "dotnet.native.wasm",
-                        buffer: <never>bins.wasm.buffer,
-                        behavior: "dotnetwasm"
-                    },
-                    ...bins.assemblies.map(a => (<never>{ name: a.name, buffer: a.content, behavior: "assembly" }))
-                ]
+                        buffer: <never>bins.wasm.buffer
+                    }],
+                    assembly: bins.assemblies.map(a => ({
+                        name: a.name,
+                        virtualPath: a.name,
+                        buffer: <never>a.content.buffer.slice(a.content.byteOffset, a.content.byteOffset + a.content.byteLength)
+                    }))
+                }
             },
             create: vi.fn(async () => {
                 const bootsharp = (await import("../cs/Test/bin/sideload")).default;
                 const dotnet = (await bootsharp.dotnet.getMain(root)).dotnet;
-                return await dotnet.withConfig(<never>customs.config).create();
+                return await dotnet.withConfig(customs.config!).create();
             }),
             import: vi.fn(),
             run: vi.fn(),
@@ -201,7 +199,7 @@ describe("boot", () => {
         const { side: { bootsharp }, root } = await setup();
         vi.doMock("../cs/Test/bin/sideload/dotnet.g", () => ({ mt: true }));
         const config = await bootsharp.dotnet.buildConfig(bootsharp.resources, root);
-        expect(config.assets!.some(a => a.behavior === "js-module-threads")).toBeTruthy();
+        expect(config.resources!.jsModuleWorker?.length).toStrictEqual(1);
         vi.doUnmock("../cs/Test/bin/sideload/dotnet.g");
     });
 });


### PR DESCRIPTION
This switches from the deprecated `AssetEntry`-based config to the new one introduced in https://github.com/dotnet/runtime/pull/116300.

A minor breaking change only affects cases when override hooks were used to initialize Bootsharp.