### PR TITLE
feat!: named wasm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Make sure to follow this convention strictly.
 
 # Packaging Bootsharp
 
-Follow these steps exactly and sequentially whenever the Bootsharp package consumed by other projects must be actualized, or when running the JS end-to-end tests after modifying the package's C# or JS code.
+Follow these steps exactly and sequentially whenever the Bootsharp package consumed by other projects (eg, samples) must be actualized, or when running the JS end-to-end tests after modifying the package's C# or JS code.
 
 1. Build the JS package with `npm run build` under `src/js`.
 2. Bump the Bootsharp library alpha version in `src/cs/Directory.Build.props`

--- a/docs/guide/build-config.md
+++ b/docs/guide/build-config.md
@@ -4,7 +4,7 @@ Build and publish related options are configured in `.csproj` file via MSBuild p
 
 | Property                   | Default          | Description                                                                       |
 |----------------------------|------------------|-----------------------------------------------------------------------------------|
-| BootsharpName              | bootsharp        | Name of the generated JavaScript module.                                          |
+| BootsharpName              | bootsharp        | Name of the generated JavaScript package and WASM binary. |
 | BootsharpPublishDirectory  | /bin/bootsharp   | Directory to publish generated JavaScript module.                                 |
 | BootsharpBinariesDirectory | (empty)          | Directory to publish binaries; when empty, binaries are embedded (see [Sideloading](sideloading)). |
 | BootsharpPackageDirectory  | project-dir      | Directory to publish `package.json` file.                                         |

--- a/docs/guide/sideloading.md
+++ b/docs/guide/sideloading.md
@@ -10,7 +10,7 @@ To disable embedding, set `BootsharpBinariesDirectory` to the directory where th
 </PropertyGroup>
 ```
 
-The `dotnet.native.wasm`, solution assemblies, ICU data and (in debug builds) debug symbols will be emitted to that directory as separate files instead of being inlined into the module. You then have two ways to feed them to `boot`:
+The compiled WASM module, solution assemblies, ICU data and (in debug builds) debug symbols will be emitted to that directory as separate files instead of being inlined into the module. You then have two ways to feed them to `boot`:
 
 Pass a root URL to fetch the resources from at runtime:
 
@@ -24,7 +24,7 @@ Or load the binaries yourself and pass them as a `BootResources` object:
 ```ts
 import { readFileSync } from "node:fs";
 
-const wasm = readFileSync("public/dotnet.native.wasm");
+const wasm = readFileSync("public/bootsharp.wasm");
 await bootsharp.boot({ wasm });
 ```
 

--- a/src/cs/Bootsharp.Publish.Test/GenerateJS/GenerateJSTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateJS/GenerateJSTest.cs
@@ -18,7 +18,7 @@ public class GenerateJSTest : TaskTest
         Project.WriteFile("dotnet.native.js", MockNativeContent);
         Project.WriteFile("dotnet.runtime.g.js", "MockRuntimeGeneratedContent");
         Project.WriteFile("dotnet.native.g.js", "MockNativeGeneratedContent");
-        Project.WriteFile("dotnet.native.wasm", MockWasmBinary);
+        Project.WriteFile("bootsharp.wasm", MockWasmBinary);
     }
 
     public override void Execute ()
@@ -39,6 +39,7 @@ public class GenerateJSTest : TaskTest
         DebugDirectory = Project.Root,
         InspectedDirectory = Project.Root,
         EntryAssemblyName = "System.Runtime.dll",
+        PackageName = "bootsharp",
         BuildEngine = Engine,
         Globalization = false,
         LLVM = false,

--- a/src/cs/Bootsharp.Publish/GenerateJS/GenerateJS.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/GenerateJS.cs
@@ -9,6 +9,7 @@ public sealed class GenerateJS : Microsoft.Build.Utilities.Task
     public required string DebugDirectory { get; set; }
     public required string InspectedDirectory { get; set; }
     public required string EntryAssemblyName { get; set; }
+    public required string PackageName { get; set; }
     public required bool Globalization { get; set; }
     public required bool LLVM { get; set; }
     public required bool Debug { get; set; }
@@ -84,7 +85,7 @@ public sealed class GenerateJS : Microsoft.Build.Utilities.Task
 
     private void GenerateResources (SolutionInspection spec)
     {
-        var generator = new ResourceGenerator(EntryAssemblyName, Debug, Globalization, Embed);
+        var generator = new ResourceGenerator(EntryAssemblyName, PackageName, Debug, Globalization, Embed);
         var content = generator.Generate(BuildDirectory, DebugDirectory);
         WriteGenerated("resources.g.mjs", content);
     }

--- a/src/cs/Bootsharp.Publish/GenerateJS/ResourceGenerator.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/ResourceGenerator.cs
@@ -4,7 +4,7 @@ namespace Bootsharp.Publish;
 /// Generates a manifest listing resources required to initialize the .NET runtime,
 /// optionally embedding the binary content as base64 strings.
 /// </summary>
-internal sealed class ResourceGenerator (string entryAssemblyName, bool debug, bool g11n, bool embed)
+internal sealed class ResourceGenerator (string entryAssemblyName, string packageName, bool debug, bool g11n, bool embed)
 {
     private readonly List<string> assemblies = [];
     private readonly List<string> symbols = [];
@@ -14,8 +14,9 @@ internal sealed class ResourceGenerator (string entryAssemblyName, bool debug, b
 
     public string Generate (string buildDir, string debugDir)
     {
+        var wasmName = $"{packageName}.wasm";
         foreach (var path in Directory.GetFiles(buildDir, "*.wasm").Order())
-            if (path.EndsWith("dotnet.native.wasm")) wasm = Path.GetFileName(path);
+            if (Path.GetFileName(path) == wasmName) wasm = wasmName;
             else assemblies.Add(Path.GetFileName(path));
         if (g11n)
             foreach (var path in Directory.GetFiles(buildDir, "*.dat").Order())

--- a/src/cs/Bootsharp/Build/Bootsharp.targets
+++ b/src/cs/Bootsharp/Build/Bootsharp.targets
@@ -104,9 +104,13 @@
         </ItemGroup>
         <Copy SourceFiles="@(BsSourceFiles)" DestinationFolder="$(BsBuildDir)/%(RecursiveDir)"/>
 
+        <!-- Rename the native WASM binary to the configured Bootsharp name. -->
+        <Move SourceFiles="$(BsBuildDir)/dotnet.native.wasm"
+              DestinationFiles="$(BsBuildDir)/$(BootsharpName).wasm"/>
+
         <!-- Optimize the produced WASM with Binaryen when publishing release builds. -->
         <Exec Condition="!$(BsDebug)"
-              Command="wasm-opt dotnet.native.wasm -O3 -o dotnet.native.wasm --all-features --strip-dwarf --strip-debug --vacuum"
+              Command="wasm-opt $(BootsharpName).wasm -O3 -o $(BootsharpName).wasm --all-features --strip-dwarf --strip-debug --vacuum"
               WorkingDirectory="$(BsBuildDir)"
               StdOutEncoding="utf-8" StdErrEncoding="utf-8"
               IgnoreExitCode="true">
@@ -120,6 +124,7 @@
                     DebugDirectory="$(PublishDir)"
                     InspectedDirectory="$(OutputPath)"
                     EntryAssemblyName="$(BsEntryAssembly)"
+                    PackageName="$(BootsharpName)"
                     Globalization="$(BsGlobalization)"
                     LLVM="$(BsLlvm)"
                     Debug="$(BsDebug)"

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.0-alpha.361</Version>
+        <Version>0.8.0-alpha.363</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>

--- a/src/js/test/spec/boot.spec.ts
+++ b/src/js/test/spec/boot.spec.ts
@@ -86,7 +86,7 @@ describe("boot", () => {
         try { await bootsharp.boot("/bin"); }
         finally { global.fetch = fetch; }
         expect(Program.onMainInvoked).toHaveBeenCalled();
-        expect(fetchSpy).toHaveBeenCalledWith("/bin/dotnet.native.wasm");
+        expect(fetchSpy).toHaveBeenCalledWith("/bin/bootsharp.wasm");
         expect(fetchSpy).toHaveBeenCalledWith("/bin/Bootsharp.Common.wasm");
     });
     it("respects boot customs", async () => {
@@ -104,7 +104,7 @@ describe("boot", () => {
                         resolvedUrl: resolve("test/cs/Test/bin/bootsharp/dotnet/dotnet.native.js")
                     }],
                     wasmNative: [{
-                        name: "dotnet.native.wasm",
+                        name: "bootsharp.wasm",
                         buffer: resources.wasm as ArrayBuffer
                     }],
                     assembly: resources.assemblies?.map(a => ({


### PR DESCRIPTION
This makes the generated WASM binary share the name of the JavaScript package, configurable with `BootsharpName` MSBuild property.