### PR TITLE
feat: improve specialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,12 @@ We have a strict 100% coverage policy for both the C# and JS codebases.
 - No unreachable code is allowed, except in rare cases where testing is not practical.
 - Treat branch coverage as part of the requirement, not just line coverage.
 
-To check C# coverage, use `reportgenerator` on merged coverlet output. Example workflow reference: `src/cs/.scripts/cover.sh`. Do not run that script verbatim in automation; it is intended for interactive usage.
+To check C# coverage, run following commands under `src/cs`:
+
+- `rm -rf .cover`
+- `dotnet test --collect:"XPlat Code Coverage;Format=opencover;ExcludeByAttribute=GeneratedCodeAttribute" --results-directory .cover`
+- `reportgenerator -reports:'.cover/**/coverage.opencover.xml' -targetdir:.cover/report "-reporttypes:TextSummary;lcov"`
+- Read coverage status from reportgenerator's summary; use the lcov output to find the exact uncovered positions, if any.
 
 To check JS coverage, run `npm run cover` under `src/js`.
 

--- a/docs/guide/specialization.md
+++ b/docs/guide/specialization.md
@@ -46,15 +46,21 @@ const comparer = Program.getComparer();
 comparer.compare("a", "b"); // -1
 ```
 
-## Injecting JavaScript
+## Injecting Code
 
-The `[SpecializeImport]` attribute accepts optional `JS` and `Decl` snippets that are spliced verbatim into the generated JavaScript proxy class and its TypeScript declaration. This lets the imported proxy satisfy JS-side contracts that aren't expressible through the C# abstract members alone — for example, injecting an iterator:
+The `[SpecializeImport]` attribute accepts optional `CS`, `JS`, `JSCtor` and `Decl` snippets that are spliced verbatim into the generated C# or JavaScript proxies and its TypeScript declaration. This lets the imported proxy satisfy JS-side contracts that aren't expressible through the C# abstract members alone — for example, injecting an iterator:
 
 ```csharp
 [SpecializeImport(typeof(ICustomCollection<>),
     JS: "[Symbol.iterator]() { return this.copy()[Symbol.iterator](); }",
     Decl: "[Symbol.iterator](): IterableIterator<T>;")]
 ```
+
+When `Decl` value starts with `export ` — the content will replace the entire TypeScript declaration of the type, instead of splicing it into the bottom of the default type declaration.
+
+::: tip EXAMPLE
+Find a more advanced example of injecting C# and JS constructor code to synthesise property events in the [E2E test project](https://github.com/elringus/bootsharp/tree/main/src/js/test/cs/Test.Library/Specialization.cs).
+:::
 
 ## Unwrapping
 

--- a/src/cs/Bootsharp.Common.Test/TypesTest.cs
+++ b/src/cs/Bootsharp.Common.Test/TypesTest.cs
@@ -19,7 +19,9 @@ public class TypesTest
         Assert.Equal([typeof(IFrontend)], new ImportAttribute(typeof(IFrontend)).Types);
         Assert.Equal(typeof(IBackend), new SpecializeExportAttribute(typeof(IBackend)).Clr);
         Assert.Equal(typeof(IFrontend), new SpecializeImportAttribute(typeof(IFrontend)).Clr);
+        Assert.Equal("CS", new SpecializeImportAttribute(typeof(IFrontend), CS: "CS").CS);
         Assert.Equal("JS", new SpecializeImportAttribute(typeof(IFrontend), JS: "JS").JS);
+        Assert.Equal("JSCtor", new SpecializeImportAttribute(typeof(IFrontend), JSCtor: "JSCtor").JSCtor);
         Assert.Equal("Decl", new SpecializeImportAttribute(typeof(IFrontend), Decl: "Decl").Decl);
     }
 

--- a/src/cs/Bootsharp.Common/Attributes/SpecializeImportAttribute.cs
+++ b/src/cs/Bootsharp.Common/Attributes/SpecializeImportAttribute.cs
@@ -8,18 +8,28 @@ namespace Bootsharp;
 /// specialization of the class annotated with <see cref="SpecializeExportAttribute"/>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
-public sealed class SpecializeImportAttribute (Type clr, string? JS = null, string? Decl = null) : Attribute
+public sealed class SpecializeImportAttribute (Type clr, string? CS = null, string? JS = null,
+    string? JSCtor = null, string? Decl = null) : Attribute
 {
     /// <summary>
     /// The CLR type to specialize the import for.
     /// </summary>
     public Type Clr { get; } = clr;
     /// <summary>
-    /// Raw snippet spliced into the generated JavaScript proxy class.
+    /// Raw snippet spliced into the generated C# import proxy class body.
+    /// </summary>
+    public string? CS { get; } = CS;
+    /// <summary>
+    /// Raw snippet spliced into the generated JavaScript export proxy class body.
     /// </summary>
     public string? JS { get; } = JS;
     /// <summary>
+    /// Raw snippet spliced into the generated JavaScript export proxy constructor.
+    /// </summary>
+    public string? JSCtor { get; } = JSCtor;
+    /// <summary>
     /// Raw snippet spliced into the generated TypeScript declaration.
+    /// When starts with 'export ' will instead replace the whole declaration.
     /// </summary>
     public string? Decl { get; } = Decl;
 }

--- a/src/cs/Bootsharp.Common/Interop/Instances.cs
+++ b/src/cs/Bootsharp.Common/Interop/Instances.cs
@@ -15,9 +15,9 @@ public static class Instances
     /// Invoked on <see cref="Export"/> when registering the instance.
     /// </summary>
     /// <param name="id">The unique identifier of the instance.</param>
-    /// <param name="instance">The registered instance.</param>
+    /// <param name="it">The registered instance.</param>
     /// <returns>The callback to invoke when disposing the instance.</returns>
-    public delegate Action ExportCallback<T> (int id, T instance) where T : class;
+    public delegate Action ExportCallback<T> (int id, T it) where T : class;
 
     private static readonly Dictionary<int, WeakReference> importedById = [];
     private static readonly Dictionary<Type, Func<int, object>> importers = [];
@@ -57,9 +57,9 @@ public static class Instances
         if (it is JSProxy js) return js._id;
         if (it is Delegate { Target: JSProxy del }) return del._id;
         if (it is SpecializedExport { _it: JSProxy ejs }) return ejs._id;
-        if (idByExported.TryGetValue(it, out var id)) return id;
+        if (idByExported.TryGetValue(Key(it), out var id)) return id;
         id = idPool.Count > 0 ? idPool.Dequeue() : nextId++;
-        exportedById[idByExported[it] = id] = it;
+        exportedById[idByExported[Key(it)] = id] = it;
         if (cb != null) onDisposeById[id] = cb(id, it);
         return id;
     }
@@ -78,7 +78,7 @@ public static class Instances
     /// </summary>
     public static void DisposeExported (int id)
     {
-        if (exportedById.Remove(id, out var instance)) idByExported.Remove(instance);
+        if (exportedById.Remove(id, out var it)) idByExported.Remove(Key(it));
         if (onDisposeById.Remove(id, out var onDispose)) onDispose();
         idPool.Enqueue(id);
     }
@@ -98,5 +98,11 @@ public static class Instances
     public static void DisposeImported (int id)
     {
         importedById.Remove(id);
+    }
+
+    private static object Key (object it)
+    {
+        // preserves specialized export instance identity
+        return it is SpecializedExport sp ? sp._it : it;
     }
 }

--- a/src/cs/Bootsharp.Common/Specialization/Specialized.cs
+++ b/src/cs/Bootsharp.Common/Specialization/Specialized.cs
@@ -152,14 +152,14 @@ public static class Specialized
         public abstract bool IsCancellationRequested { get; }
 
         internal static readonly ConditionalWeakTable
-            <CancellationTokenSource, CancellationTokenImport> ImportBySrc = new();
+            <CancellationTokenSource, CancellationTokenImport> ImportedBySrc = new();
         private CancellationTokenSource? src;
 
         protected internal override object Unwrap ()
         {
             if (src == null)
             {
-                ImportBySrc.Add(src = new(), this);
+                ImportedBySrc.Add(src = new(), this);
                 if (IsCancellationRequested) src.Cancel();
                 else OnCancellationRequested += src.Cancel;
             }
@@ -187,7 +187,7 @@ public static class Specialized
             // Preserving the imported token's cancellation sources identity
             // when they round trip via an exported interop API.
             if (GetSource(ref ct) is not { } src) return ct;
-            return CancellationTokenImport.ImportBySrc.TryGetValue(src, out var i) ? i : ct;
+            return CancellationTokenImport.ImportedBySrc.TryGetValue(src, out var i) ? i : ct;
             [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_source")]
             static extern ref CancellationTokenSource? GetSource (ref CancellationToken ct);
         }

--- a/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInstanceTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInstanceTest.cs
@@ -193,7 +193,7 @@ public class CSInstanceTest : GenerateCSTest
             {
                 ~JS_Import_System_Func_Of_System_Int32_And_System_String() => Instances.DisposeImported(_id);
 
-                public global::System.String? Invoke (global::System.Int32 arg) => global::Bootsharp.Generated.Interop.JS_Import_System_Func_Of_System_Int32_And_System_String_Invoke(_id, arg);
+                public global::System.String Invoke (global::System.Int32 arg) => global::Bootsharp.Generated.Interop.JS_Import_System_Func_Of_System_Int32_And_System_String_Invoke(_id, arg);
             }
             """);
         Contains(

--- a/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInteropTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInteropTest.cs
@@ -489,6 +489,31 @@ public class CSInteropTest : GenerateCSTest
     }
 
     [Fact]
+    public void SerializedDelegatesKeepDirection ()
+    {
+        AddAssembly(With(
+            """
+            public delegate void Imported ();
+            public delegate void Exported ();
+            public interface IFoo { string Value { get; set; } }
+            public interface IBar { string Value { get; set; } }
+            public record RecordX (IFoo Foo, Imported Cb);
+            public record RecordY (IBar Bar, Exported Cb);
+
+            public class Class
+            {
+                [Export] public static RecordY Export () => default!;
+                [Import] public static RecordX Import () => default!;
+            }
+            """));
+        Execute();
+        Contains("JS_Import_Imported_Invoke");
+        Contains("JS_Export_Exported_Invoke");
+        DoesNotContain("JS_Export_Imported");
+        DoesNotContain("JS_Import_Exported");
+    }
+
+    [Fact]
     public void EscapesReservedArgumentNames ()
     {
         AddAssembly(WithClass("[Export] public static void Foo (string @object, int @class) {}"));

--- a/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInteropTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateCS/CSInteropTest.cs
@@ -434,6 +434,23 @@ public class CSInteropTest : GenerateCSTest
     }
 
     [Fact]
+    public void GeneratesNullableGenericValueType ()
+    {
+        AddAssembly(With(
+            """
+            namespace Space;
+
+            public class Class
+            {
+                [Import] public static KeyValuePair<int, string?>? Fun (KeyValuePair<int, string?>? a) =>
+                    Proxies.Get<Func<KeyValuePair<int, string?>?, KeyValuePair<int, string?>?>>("Space.Class.Fun")(a);
+            }
+            """));
+        Execute();
+        Contains("KeyValuePair<global::System.Int32, global::System.String?>? Space_Class_Fun (global::System.Collections.Generic.KeyValuePair<global::System.Int32, global::System.String?>? a) =>");
+    }
+
+    [Fact]
     public void DoesNotSerializeTypesThatShouldNotBeSerialized ()
     {
         AddAssembly(With(

--- a/src/cs/Bootsharp.Publish.Test/GenerateJS/DeclarationTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateJS/DeclarationTest.cs
@@ -151,9 +151,9 @@ public class DeclarationTest : GenerateJSTest
         Contains("foo.g.d.mts",
             """
             export namespace Class {
-                export const expEvt: Event<[]>;
-                export const evt: Event<[obj: string | undefined]>;
-                export const impEvt: Event<[arg1: number, arg2: boolean | undefined]>;
+                export const expEvt: $bcl.Event<[]>;
+                export const evt: $bcl.Event<[obj: string | undefined]>;
+                export const impEvt: $bcl.Event<[arg1: number, arg2: boolean | undefined]>;
             }
             """);
     }
@@ -381,6 +381,23 @@ public class DeclarationTest : GenerateJSTest
                 readonly token: system_threading.CancellationToken;
             }
             """);
+    }
+
+    [Fact]
+    public void SpecializedDeclarationStartingWithExportReplacesWholeDeclaration ()
+    {
+        AddAssembly(With(
+            """
+            public class Foo;
+            [SpecializeImport(typeof(Foo), Decl: "export type Foo = () => void;")]
+            public abstract class FooImport (int id) : SpecializedImport(id);
+            [SpecializeExport(typeof(Foo))]
+            public sealed class FooExport (Foo it) : SpecializedExport(it);
+            public class Class { [Export] public static Foo Get () => default; }
+            """));
+        Execute();
+        Contains("export type Foo = () => void;");
+        DoesNotContain("export interface Foo");
     }
 
     [Fact]
@@ -963,10 +980,10 @@ public class DeclarationTest : GenerateJSTest
         Contains(
             """
             export namespace IExported {
-                export const evt: Event<[arg1: string, arg2: Info, arg3: IExportedInstanced]>;
+                export const evt: $bcl.Event<[arg1: string, arg2: Info, arg3: IExportedInstanced]>;
             }
             export namespace IImported {
-                export const evt: Event<[arg1: string, arg2: Info, arg3: IImportedInstanced]>;
+                export const evt: $bcl.Event<[arg1: string, arg2: Info, arg3: IImportedInstanced]>;
             }
             export interface IExportedInstanced {
             }
@@ -1002,11 +1019,11 @@ public class DeclarationTest : GenerateJSTest
                 export let getImported: (it: IExported) => IImported;
             }
             export interface IImported {
-                changed: Event<[arg1: IImported, arg2: Info, arg3: string]>;
+                changed: $bcl.Event<[arg1: IImported, arg2: Info, arg3: string]>;
             }
             export interface IExported {
-                changed: Event<[obj: Info]>;
-                done: Event<[]>;
+                changed: $bcl.Event<[obj: Info]>;
+                done: $bcl.Event<[]>;
             }
             export type Info = Readonly<{
                 value: string;
@@ -1346,7 +1363,7 @@ public class DeclarationTest : GenerateJSTest
         Contains(
             """
             export namespace Foo {
-                export const qux: Event<[]>;
+                export const qux: $bcl.Event<[]>;
                 export let baz: Enum;
                 export function bar(): Enum;
             }
@@ -1398,7 +1415,7 @@ public class DeclarationTest : GenerateJSTest
         Contains(
             """
             export namespace Foo {
-                export const quz: Event<[]>;
+                export const quz: $bcl.Event<[]>;
                 export let qux: Enum;
                 export function bar(e: Enum): void;
                 export let baz: (e: Enum) => void;
@@ -1452,7 +1469,7 @@ public class DeclarationTest : GenerateJSTest
                 export function get(): Foo;
             }
             export interface Foo {
-                qux: Event<[]>;
+                qux: $bcl.Event<[]>;
                 baz: Enum;
                 bar(e: Enum): void;
             }
@@ -1538,7 +1555,7 @@ public class DeclarationTest : GenerateJSTest
             /// <summary>Payload changed callback.</summary>
             /// <param name="payload">Payload from custom delegate.</param>
             /// <param name="label">Label from custom delegate.</param>
-            public delegate void PayloadChanged (Payload<int> payload, string label);
+            public delegate void PayloadChanged (Payload<int> payload, string label, int op);
 
             /// <summary>
             /// Exported instance API.
@@ -1584,6 +1601,9 @@ public class DeclarationTest : GenerateJSTest
                 /// <summary>Gets exported instance.</summary>
                 [Export] public static IExportedInstanced GetExported () => default;
 
+                /// <summary>Gets the payload callback delegate.</summary>
+                [Export] public static PayloadChanged GetDelegate () => default;
+
                 /// <summary>Receives foo.</summary>
                 /// <param name="count">Count to receive.</param>
                 [Import] public static void OnFoo (Payload<int> count) { }
@@ -1624,6 +1644,15 @@ public class DeclarationTest : GenerateJSTest
         Contains(
             """
             /**
+             * Payload changed callback.
+             * @param payload Payload from custom delegate.
+             * @param label Label from custom delegate.
+             */
+            export type PayloadChanged = (payload: Payload<number>, label: string, op: number) => void;
+            """);
+        Contains(
+            """
+            /**
              * Exported instance API.
              */
             export interface IExportedInstanced {
@@ -1647,23 +1676,23 @@ public class DeclarationTest : GenerateJSTest
                 /**
                  * Exports completion signal.
                  */
-                export const expEvt: Event<[obj: boolean]>;
+                export const expEvt: $bcl.Event<[obj: boolean]>;
                 /**
                  * Imports completion signal.
                  */
-                export const impEvt: Event<[arg1: string, arg2: number]>;
+                export const impEvt: $bcl.Event<[arg1: string, arg2: number]>;
                 /**
                  * Exports payload changes.
                  * @param payload Payload from custom delegate.
                  * @param label Label from custom delegate.
                  */
-                export const payloadChanged: Event<[payload: Payload<number>, label: string]>;
+                export const payloadChanged: $bcl.Event<[payload: Payload<number>, label: string, op: number]>;
                 /**
                  * Imports handler signal.
                  * @param sender Sender from event handler.
                  * @param e Payload from event handler.
                  */
-                export const handlerEvt: Event<[sender: any | undefined, e: HandlerArgs]>;
+                export const handlerEvt: $bcl.Event<[sender: any | undefined, e: HandlerArgs]>;
                 /**
                  * Runs foo.
                  * @param fn Function value.
@@ -1679,6 +1708,10 @@ public class DeclarationTest : GenerateJSTest
                  * Gets exported instance.
                  */
                 export function getExported(): IExportedInstanced;
+                /**
+                 * Gets the payload callback delegate.
+                 */
+                export function getDelegate(): PayloadChanged;
                 /**
                  * Receives foo.
                  * @param count Count to receive.

--- a/src/cs/Bootsharp.Publish.Test/GenerateJS/JSInstanceTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateJS/JSInstanceTest.cs
@@ -193,7 +193,7 @@ public class JSInstanceTest : GenerateJSTest
             """
             $i.System_Func_Of_System_Int32_And_System_String = class JS_Export_System_Func_Of_System_Int32_And_System_String {
                 constructor(_id) {
-                    const fn = (arg) => system.Func_Of_Int32_And_String.invoke(_id, arg);
+                    const fn = (arg) => system.Func_Of_System_Int32_And_System_String.invoke(_id, arg);
                     fn._id = _id;
                     return fn;
                 }

--- a/src/cs/Bootsharp.Publish.Test/GenerateJS/JSModuleTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateJS/JSModuleTest.cs
@@ -311,7 +311,7 @@ public class JSModuleTest : GenerateJSTest
                 impEvt: importEvent((arg1, arg2) => exports.Class_InvokeImpEvt(arg1, serialize(arg2, $s.Info))),
                 foo: (i) => deserialize(exports.Class_Foo(serialize(i, $s.Info)), $s.Info),
                 get bar() { return this.barHandler; },
-                set bar(handler) { this.barHandler = handler; this.barSerializedHandler = (i) => serialize(this.barHandler(deserialize(i, $s.Info)), $s.Info); },
+                set bar(handler) { this.barHandler = handler; this.barSerializedHandler = (i) => serialize(this.barHandler(deserialize(i, $s.Info) ?? undefined), $s.Info); },
                 get barSerialized() { return this.barSerializedHandler; }
             };
             """);
@@ -332,7 +332,7 @@ public class JSModuleTest : GenerateJSTest
             export const Class = {
                 foo: async (i) => deserialize(await exports.Class_Foo(serialize(i, $s.Info)), $s.Info),
                 get bar() { return this.barHandler; },
-                set bar(handler) { this.barHandler = handler; this.barSerializedHandler = async (i) => serialize(await this.barHandler(deserialize(i, $s.Info)), $s.Info); },
+                set bar(handler) { this.barHandler = handler; this.barSerializedHandler = async (i) => serialize(await this.barHandler(deserialize(i, $s.Info) ?? undefined), $s.Info); },
                 get barSerialized() { return this.barSerializedHandler; },
                 baz: async () => deserialize(await exports.Class_Baz(), $s.System_Collections_Generic_IReadOnlyList_Of_Info),
                 get yaz() { return this.yazHandler; },
@@ -798,6 +798,57 @@ public class JSModuleTest : GenerateJSTest
         Execute();
         Contains("makeOfCircle:");
         DoesNotContain("makeOfJS_Import_Leaked");
+    }
+
+    [Fact]
+    public void GenericArgumentNullabilityFollowsTypeArgument ()
+    {
+        AddAssembly(With(
+            """
+            public interface IFoo { void Foo (); }
+            public interface IBar { void Bar (); }
+            public record Data (string Id);
+            public record struct Point (int X);
+
+            public interface IBox<T> { void Set (T val); void SetOpt (T? opt); }
+            [SpecializeImport(typeof(IBox<>))]
+            public abstract class BoxImport<T> (int id) : SpecializedImport(id), IBox<T>
+            {
+                public abstract void Set (T val);
+                public abstract void SetOpt (T? opt);
+            }
+            [SpecializeExport(typeof(IBox<>))]
+            public class BoxExport<T> (IBox<T> box) : SpecializedExport(box)
+            {
+                public void Set (T val) => box.Set(val);
+                public void SetOpt (T? opt) => box.SetOpt(opt);
+            }
+
+            public delegate void Plain<T> (T caller);
+            public delegate void Opt<T> (T thing);
+            public delegate void OnData<T> (T data);
+            public delegate void OnPoint<T> (T pt);
+            public record Rec (Plain<IFoo>? OnFoo, Opt<IBar?>? OnBar, OnData<Data>? OnDataReq, OnPoint<Point?>? OnPt);
+
+            public class Class
+            {
+                [Import] public static IBox<string> ImportBox () => default!;
+                [Import] public static IBox<Data> ImportDataBox () => default!;
+                [Export] public static IBox<string> ExportBox () => default!;
+                [Export] public static void UseRec (Rec rec) { }
+            }
+            """));
+        Execute();
+        // Not nullable (does not contain ?? undefined).
+        Contains("$i.imported(_id).set(val)");
+        Contains("$i.imported(_id).set(deserialize(val, $s.Data))");
+        Contains("$i.imported(_id)($i.resolve(caller, $i.IFoo))");
+        Contains("$i.imported(_id)(deserialize(data, $s.Data))");
+        // Nullable (contains ?? undefined).
+        Contains("$i.imported(_id).setOpt(opt ?? undefined)");
+        Contains("$i.imported(_id).setOpt(deserialize(opt, $s.Data) ?? undefined)");
+        Contains("$i.imported(_id)($i.resolve(thing, $i.IBar) ?? undefined)");
+        Contains("$i.imported(_id)(deserialize(pt, $s.PointOrNull) ?? undefined)");
     }
 
     [Fact]

--- a/src/cs/Bootsharp.Publish.Test/GenerateJS/JSModuleTest.cs
+++ b/src/cs/Bootsharp.Publish.Test/GenerateJS/JSModuleTest.cs
@@ -852,6 +852,27 @@ public class JSModuleTest : GenerateJSTest
     }
 
     [Fact]
+    public void DisambiguatesNodesByFullGenericArgName ()
+    {
+        AddAssembly(With(
+            """
+            namespace A { public record Item; }
+            namespace B { public record Item; }
+
+            public interface IBox<T> { void Set (T item); }
+
+            public class Class
+            {
+                [Export] public static IBox<A.Item> GetA () => default!;
+                [Export] public static IBox<B.Item> GetB () => default!;
+            }
+            """));
+        Execute();
+        Contains("export const IBox_Of_A_Item = {");
+        Contains("export const IBox_Of_B_Item = {");
+    }
+
+    [Fact]
     public void RespectsPrefsInStatics ()
     {
         AddAssembly(With(

--- a/src/cs/Bootsharp.Publish/Common/Global/GlobalText.cs
+++ b/src/cs/Bootsharp.Publish/Common/Global/GlobalText.cs
@@ -1,5 +1,4 @@
 global using static Bootsharp.Publish.GlobalText;
-using System.Text;
 
 namespace Bootsharp.Publish;
 
@@ -31,16 +30,5 @@ internal static class GlobalText
     {
         if (value.Length == 1) return value.ToUpperInvariant();
         return char.ToUpperInvariant(value[0]) + value[1..];
-    }
-
-    public static string Slugify (string value)
-    {
-        var bld = new StringBuilder(value.Length + 4);
-        for (var i = 0; i < value.Length; i++)
-            if (value[i] == '.') bld.Append('/');
-            else if (char.IsUpper(value[i]) && i > 0 && char.IsLower(value[i - 1]))
-                bld.Append('-').Append(char.ToLowerInvariant(value[i]));
-            else bld.Append(char.ToLowerInvariant(value[i]));
-        return bld.ToString();
     }
 }

--- a/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
+++ b/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
@@ -1,4 +1,5 @@
 global using static Bootsharp.Publish.GlobalType;
+global using Nullity = System.Reflection.NullabilityInfo;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -81,31 +82,31 @@ internal static class GlobalType
         (a.IsGenericType ? a.GetGenericTypeDefinition() : a) ==
         (b.IsGenericType ? b.GetGenericTypeDefinition() : b);
 
-    public static NullabilityInfo GetNullity (PropertyInfo prop) =>
+    public static Nullity GetNullity (EventInfo evt) => new NullabilityInfoContext().Create(evt);
+    public static Nullity GetNullity (EventInfo evt, ParameterInfo param) =>
+        GetNullity(param, new NullabilityInfoContext().Create(evt));
+    public static Nullity GetNullity (PropertyInfo prop) =>
         FixNullity(new NullabilityInfoContext().Create(prop), prop.CustomAttributes, prop.DeclaringType);
-    public static NullabilityInfo GetNullity (ParameterInfo param) =>
-        FixNullity(new NullabilityInfoContext().Create(param), param.CustomAttributes, param.Member);
-    public static NullabilityInfo GetNullity (EventInfo evt) => new NullabilityInfoContext().Create(evt);
-    public static NullabilityInfo GetNullity (EventInfo evt, ParameterInfo param)
+    public static Nullity GetNullity (ParameterInfo param, Nullity? nul = null)
     {
-        if (evt.EventHandlerType!.IsGenericType)
-        {
-            var arg = evt.EventHandlerType.GetGenericTypeDefinition()
-                .GetMethod("Invoke")!.GetParameters()[param.Position].ParameterType;
-            if (arg.IsGenericParameter)
-                return GetNullity(evt).GenericTypeArguments[arg.GenericParameterPosition];
-        }
-        return GetNullity(param);
+        var self = FixNullity(new NullabilityInfoContext().Create(param), param.CustomAttributes, param.Member);
+        if (nul?.GenericTypeArguments is not { Length: > 0 } args) return self;
+        // resolve nullability from the open (unbound) generic form of the method
+        var method = param.Member.Module.ResolveMethod(((MethodBase)param.Member).MetadataToken)!;
+        param = param.Position < 0 ? ((MethodInfo)method).ReturnParameter : method.GetParameters()[param.Position];
+        if (!param.ParameterType.IsGenericParameter) return self;
+        if (IsNullable(GetNullity(param))) return self;
+        return args[param.ParameterType.GenericParameterPosition];
     }
 
-    public static bool IsNullable (NullabilityInfo? info) => info?.ReadState == NullabilityState.Nullable;
-    public static bool IsNullable (Type type, NullabilityInfo? info) => IsNullable(type, info, out _);
+    public static bool IsNullable (Nullity? nul) => nul?.ReadState == NullabilityState.Nullable;
+    public static bool IsNullable (Type type, Nullity? nul) => IsNullable(type, nul, out _);
     public static bool IsNullable (Type type, [NotNullWhen(true)] out Type? value) => IsNullable(type, null, out value);
-    public static bool IsNullable (Type type, NullabilityInfo? info, [NotNullWhen(true)] out Type? value)
+    public static bool IsNullable (Type type, Nullity? nul, [NotNullWhen(true)] out Type? value)
     {
         if (type.IsGenericType && type.Name.Contains("Nullable`") && type.GenericTypeArguments.Length == 1)
             value = type.GenericTypeArguments[0];
-        else if (IsNullable(info)) value = type;
+        else if (IsNullable(nul)) value = type;
         else value = null;
         return value != null;
     }
@@ -116,7 +117,7 @@ internal static class GlobalType
         return $"_id, {args}";
     }
 
-    public static string BuildId (Type type, NullabilityInfo? nul = null, bool full = true, char separator = '_')
+    public static string BuildId (Type type, Nullity? nul = null, bool full = true, char separator = '_')
     {
         var sb = new StringBuilder();
         foreach (var c in BuildSyntax(type, nul, full: full).Replace("global::", ""))
@@ -129,7 +130,7 @@ internal static class GlobalType
         return sb.ToString();
     }
 
-    public static string BuildSyntax (Type type, NullabilityInfo? nul = null, bool forceNil = false, bool full = true)
+    public static string BuildSyntax (Type type, Nullity? nul = null, bool forceNil = false, bool full = true)
     {
         var nil = (forceNil || IsNullable(nul)) ? "?" : "";
         var global = full ? "global::" : "";
@@ -178,7 +179,8 @@ internal static class GlobalType
         return exp;
     }
 
-    public static string ExportJS (ArgumentMeta arg) => ExportJS(arg.Value, arg.JSName);
+    public static string ExportJS (ArgumentMeta arg) // arguments are undefined (not null) by convention
+        => ExportJS(arg.Value, arg.JSName) + (arg.Value.Nullable ? " ?? undefined" : "");
     public static string ExportJS (ValueMeta value, string exp) => ExportJS(value.Type, exp);
     public static string ExportJS (TypeMeta type, string exp)
     {
@@ -198,8 +200,7 @@ internal static class GlobalType
         return exp;
     }
 
-    private static NullabilityInfo FixNullity (NullabilityInfo nul,
-        IEnumerable<CustomAttributeData> attrs, MemberInfo? scope)
+    private static Nullity FixNullity (Nullity nul, IEnumerable<CustomAttributeData> attrs, MemberInfo? scope)
     {
         // Nullity is conservatively reported as nullable for unconstrained generic parameters; this workaround
         // resolves actual nullability via a compiler heuristic. https://github.com/dotnet/runtime/issues/115014
@@ -223,8 +224,8 @@ internal static class GlobalType
         }
 
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_ReadState")]
-        static extern void SetReadState (NullabilityInfo info, NullabilityState value);
+        static extern void SetReadState (Nullity nul, NullabilityState value);
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_WriteState")]
-        static extern void SetWriteState (NullabilityInfo info, NullabilityState value);
+        static extern void SetWriteState (Nullity nul, NullabilityState value);
     }
 }

--- a/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
+++ b/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
@@ -130,9 +130,9 @@ internal static class GlobalType
         return sb.ToString();
     }
 
-    public static string BuildSyntax (Type type, Nullity? nul = null, bool forceNil = false)
+    public static string BuildSyntax (Type type, Nullity? nul = null)
     {
-        var nil = (forceNil || IsNullable(nul)) ? "?" : "";
+        var nil = IsNullable(nul) ? "?" : "";
         if (IsVoid(type)) return "void";
         if (type.IsArray) return $"{BuildSyntax(type.GetElementType()!, nul?.ElementType)}[]{nil}";
         if (type.IsGenericType) return BuildGeneric(type, type.GenericTypeArguments);
@@ -140,10 +140,11 @@ internal static class GlobalType
 
         string BuildGeneric (Type type, Type[] args)
         {
-            if (IsNullable(type, out var value)) return BuildSyntax(value, nul, true);
+            if (IsNullable(type, out var value))
+                return BuildSyntax(value, value.IsGenericType ? nul : null) + "?";
             var name = TrimGeneric(ResolveTypeName(type));
             var typeArgs = string.Join(", ", args.Select((a, i) =>
-                BuildSyntax(a, nul?.GenericTypeArguments[i], forceNil)));
+                BuildSyntax(a, nul?.GenericTypeArguments[i])));
             return $"global::{name}<{typeArgs}>";
         }
 

--- a/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
+++ b/src/cs/Bootsharp.Publish/Common/Global/GlobalType.cs
@@ -117,12 +117,12 @@ internal static class GlobalType
         return $"_id, {args}";
     }
 
-    public static string BuildId (Type type, Nullity? nul = null, bool full = true, char separator = '_')
+    public static string BuildId (Type type, Nullity? nul = null)
     {
         var sb = new StringBuilder();
-        foreach (var c in BuildSyntax(type, nul, full: full).Replace("global::", ""))
-            if (char.IsLetterOrDigit(c) || c == separator) sb.Append(c);
-            else if (c == '.') sb.Append(separator);
+        foreach (var c in BuildSyntax(type, nul).Replace("global::", ""))
+            if (char.IsLetterOrDigit(c) || c == '_') sb.Append(c);
+            else if (c == '.') sb.Append('_');
             else if (c == '?') sb.Append("OrNull");
             else if (c == '[') sb.Append("Array");
             else if (c == '<') sb.Append("_Of_");
@@ -130,29 +130,27 @@ internal static class GlobalType
         return sb.ToString();
     }
 
-    public static string BuildSyntax (Type type, Nullity? nul = null, bool forceNil = false, bool full = true)
+    public static string BuildSyntax (Type type, Nullity? nul = null, bool forceNil = false)
     {
         var nil = (forceNil || IsNullable(nul)) ? "?" : "";
-        var global = full ? "global::" : "";
         if (IsVoid(type)) return "void";
         if (type.IsArray) return $"{BuildSyntax(type.GetElementType()!, nul?.ElementType)}[]{nil}";
         if (type.IsGenericType) return BuildGeneric(type, type.GenericTypeArguments);
-        return $"{global}{ResolveTypeName(type)}{nil}";
+        return $"global::{ResolveTypeName(type)}{nil}";
 
         string BuildGeneric (Type type, Type[] args)
         {
-            if (IsNullable(type, out var value)) return BuildSyntax(value, nul, true, full);
+            if (IsNullable(type, out var value)) return BuildSyntax(value, nul, true);
             var name = TrimGeneric(ResolveTypeName(type));
             var typeArgs = string.Join(", ", args.Select((a, i) =>
-                BuildSyntax(a, nul?.GenericTypeArguments[i], forceNil, full)));
-            return $"{global}{name}<{typeArgs}>";
+                BuildSyntax(a, nul?.GenericTypeArguments[i], forceNil)));
+            return $"global::{name}<{typeArgs}>";
         }
 
-        string ResolveTypeName (Type type)
+        static string ResolveTypeName (Type type)
         {
             if (type.IsNested) return $"{ResolveTypeName(type.DeclaringType!)}.{type.Name}";
-            if (!full || type.Namespace is null) return type.Name;
-            return $"{type.Namespace}.{type.Name}";
+            return type.Namespace is null ? type.Name : $"{type.Namespace}.{type.Name}";
         }
     }
 

--- a/src/cs/Bootsharp.Publish/Common/Inspection/Meta/SurfaceMeta.cs
+++ b/src/cs/Bootsharp.Publish/Common/Inspection/Meta/SurfaceMeta.cs
@@ -99,8 +99,12 @@ internal sealed record SpecializedProxy : SurfaceProxy
     /// The export proxy type annotated with <see cref="SpecializeExportAttribute"/>.
     /// </summary>
     public required TypeMeta Export { get; init; }
+    /// <inheritdoc cref="SpecializeImportAttribute.CS"/>
+    public string? CS { get; init; }
     /// <inheritdoc cref="SpecializeImportAttribute.JS"/>
     public string? JS { get; init; }
+    /// <inheritdoc cref="SpecializeImportAttribute.JSCtor"/>
+    public string? JSCtor { get; init; }
     /// <inheritdoc cref="SpecializeImportAttribute.Decl"/>
     public string? Decl { get; init; }
 }

--- a/src/cs/Bootsharp.Publish/Common/Inspection/Meta/TypeMeta.cs
+++ b/src/cs/Bootsharp.Publish/Common/Inspection/Meta/TypeMeta.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Bootsharp.Publish;
 
 /// <summary>
@@ -21,9 +23,32 @@ internal record TypeMeta (Type Clr)
     /// <summary>
     /// The path to the module containing the node that represents the type in JavaScript.
     /// </summary>
-    public string JSModule { get; } = Clr.Namespace is { } ns ? Slugify(ns) : "index";
+    public string JSModule { get; } = BuildModule(Clr);
     /// <summary>
     /// The path to the node inside the module that represents the type in JavaScript.
     /// </summary>
-    public string JSNode { get; } = BuildId(Clr, full: false, separator: '.');
+    public string JSNode { get; } = BuildNode(Clr);
+
+    private static string BuildModule (Type type)
+    {
+        if (type.Namespace is not { } ns) return "index";
+        var bld = new StringBuilder(ns.Length + 4);
+        for (var i = 0; i < ns.Length; i++)
+            if (ns[i] == '.') bld.Append('/');
+            else if (char.IsUpper(ns[i]) && i > 0 && char.IsLower(ns[i - 1]))
+                bld.Append('-').Append(char.ToLowerInvariant(ns[i]));
+            else bld.Append(char.ToLowerInvariant(ns[i]));
+        return bld.ToString();
+    }
+
+    private static string BuildNode (Type type)
+    {
+        var node = BuildSyntax(type).Replace("global::", "");
+        if (node.StartsWith($"{type.Namespace}."))
+            node = node[(type.Namespace!.Length + 1)..];
+        var genericIdx = node.IndexOf('<');
+        if (genericIdx < 0) return node;
+        var args = string.Join("_And_", type.GenericTypeArguments.Select(a => BuildId(a)));
+        return $"{node[..genericIdx]}_Of_{args}";
+    }
 }

--- a/src/cs/Bootsharp.Publish/Common/Inspection/SerializedInspector.cs
+++ b/src/cs/Bootsharp.Publish/Common/Inspection/SerializedInspector.cs
@@ -24,12 +24,10 @@ internal sealed class SerializedInspector (TypeInspector.InspectInstanced inspec
 
     private readonly Dictionary<string, SerializedMeta> byId = [];
     private readonly HashSet<Type> cycle = [];
-    private InteropKind ik;
 
-    public SerializedMeta? Inspect (Type type, InteropKind ik)
+    public SerializedMeta? Inspect (Type type, InteropKind ik, Nullity? nul)
     {
-        this.ik = ik;
-        return IsSerialized(type) ? Build(type) : null;
+        return IsSerialized(type) ? Build(type, ik, nul) : null;
     }
 
     public IReadOnlyList<SerializedMeta> Collect ()
@@ -45,21 +43,21 @@ internal sealed class SerializedInspector (TypeInspector.InspectInstanced inspec
         return !native.Contains(type.FullName!);
     }
 
-    private SerializedMeta Build (Type type)
+    private SerializedMeta Build (Type type, InteropKind ik, Nullity? nul = null)
     {
         if (IsTaskWithResult(type, out var result)) type = result; // tasks are natively supported - ignore them
         var id = BuildId(type);
         if (byId.TryGetValue(id, out var existing)) return existing;
         if (!cycle.Add(type)) return new Discard(type); // break self-ref cycle
         var meta = byId[id] =
-            IsNullable(type, out var value) ? new SerializedNullableMeta(type, Build(value)) :
+            IsNullable(type, out var value) ? new SerializedNullableMeta(type, Build(value, ik)) :
             type.IsEnum ? new SerializedEnumMeta(type) :
             IsPrimitive(type) ? new SerializedPrimitiveMeta(type) :
-            type.IsArray ? new SerializedArrayMeta(type, Build(type.GetElementType()!)) :
-            inspectInstanced(type, ik, null) is { } it ? new SerializedInstanceMeta(it) :
-            IsList(type, out var element) ? new SerializedListMeta(type, Build(element)) :
-            IsDictionary(type, out var k, out var v) ? new SerializedDictionaryMeta(type, Build(k), Build(v)) :
-            BuildObject(type);
+            type.IsArray ? new SerializedArrayMeta(type, Build(type.GetElementType()!, ik)) :
+            inspectInstanced(type, ik, nul) is { } it ? new SerializedInstanceMeta(it) :
+            IsList(type, out var element) ? new SerializedListMeta(type, Build(element, ik)) :
+            IsDictionary(type, out var k, out var v) ? new SerializedDictionaryMeta(type, Build(k, ik), Build(v, ik)) :
+            BuildObject(type, ik);
         cycle.Remove(type);
         return meta;
     }
@@ -69,7 +67,7 @@ internal sealed class SerializedInspector (TypeInspector.InspectInstanced inspec
         type.FullName == typeof(DateTimeOffset).FullName ||
         type.FullName == typeof(nint).FullName;
 
-    private SerializedObjectMeta BuildObject (Type type)
+    private SerializedObjectMeta BuildObject (Type type, InteropKind ik)
     {
         var ctor = ResolveConstructor(type);
         var ctorParams = ctor?.GetParameters() ?? [];
@@ -80,21 +78,22 @@ internal sealed class SerializedInspector (TypeInspector.InspectInstanced inspec
             .Where(p => p.GetMethod != null && p.GetIndexParameters().Length == 0 &&
                         (p.SetMethod is { IsPublic: true } || IsAutoProperty(p)))
             .OrderBy(p => paramOrders.GetValueOrDefault(p.Name, int.MaxValue))
-            .Select(p => BuildProperty(p, paramOrders.ContainsKey(p.Name))).ToArray();
+            .Select(p => BuildProperty(p, paramOrders.ContainsKey(p.Name), ik)).ToArray();
         return new(type, props);
     }
 
-    private SerializedPropertyMeta BuildProperty (PropertyInfo prop, bool ctor)
+    private SerializedPropertyMeta BuildProperty (PropertyInfo prop, bool ctor, InteropKind ik)
     {
+        var nul = GetNullity(prop);
         var setter = prop.SetMethod is { IsPublic: true } ? prop.SetMethod : null;
         var initOnly = setter?.ReturnParameter.GetRequiredCustomModifiers()
             .Any(m => m.FullName == typeof(IsExternalInit).FullName) == true;
         return new() {
             Info = prop,
-            Type = Build(prop.PropertyType),
+            Type = Build(prop.PropertyType, ik, nul),
             Name = prop.Name,
             JSName = BuildJSName(prop.Name),
-            Nullable = IsNullable(prop.PropertyType, GetNullity(prop)),
+            Nullable = IsNullable(prop.PropertyType, nul),
             Required = prop.CustomAttributes
                 .Any(a => a.AttributeType.FullName == typeof(RequiredMemberAttribute).FullName),
             Ctor = ctor,

--- a/src/cs/Bootsharp.Publish/Common/Inspection/TypeInspector.cs
+++ b/src/cs/Bootsharp.Publish/Common/Inspection/TypeInspector.cs
@@ -5,7 +5,7 @@ namespace Bootsharp.Publish;
 
 internal sealed class TypeInspector
 {
-    internal delegate InstanceMeta? InspectInstanced (Type type, InteropKind ik, NullabilityInfo? nul);
+    internal delegate InstanceMeta? InspectInstanced (Type type, InteropKind ik, Nullity? nul);
 
     private readonly Dictionary<(string Syntax, InteropKind IK), InstanceMeta> its = [];
     private readonly Dictionary<Type, TypeMeta> crawled = [];
@@ -53,7 +53,7 @@ internal sealed class TypeInspector
                 members.Add(InspectProperty(prop, ik, st));
         foreach (var method in type.GetMethods(flags))
             if (ResolveIK(method) is { } ik)
-                members.Add(InspectMethod(method, ik, st));
+                members.Add(InspectMethod(method, ik, st, null));
         return members.Count > 0 ? st : null;
     }
 
@@ -62,18 +62,18 @@ internal sealed class TypeInspector
         if (!inspectedModuleTypes.Add(type) || IsStatic(type) ||
             (ik == InteropKind.Import && !type.IsInterface)) return null;
         var proxy = BuildProxy(type, BuildId(type), ik);
-        var members = new List<MemberMeta>();
-        return InspectMembers(new ModuleMeta(type) { IK = ik, Proxy = proxy, Members = members }, ik);
+        var md = new ModuleMeta(type) { IK = ik, Proxy = proxy, Members = new List<MemberMeta>() };
+        return InspectMembers(md, ik, null);
     }
 
-    private InstanceMeta? InspectInstance (Type type, InteropKind ik, NullabilityInfo? nul)
+    private InstanceMeta? InspectInstance (Type type, InteropKind ik, Nullity? nul)
     {
         var id = BuildId(type, type.IsGenericType ? nul : null); // nullity only matter for generic args
         var key = (id, ik);
         if (its.TryGetValue(key, out var it)) return it;
         if (IsTaskWithResult(type, out var result)) return InspectInstance(result, ik, nul!.GenericTypeArguments[0]);
         if (!IsInstanced(type)) return null;
-        if (IsDelegate(type)) return its[key] = InspectDelegate(type, ik);
+        if (IsDelegate(type)) return its[key] = InspectDelegate(type, ik, nul);
         if (!Preferences.IsSpecialized(type, out var sp) && ik == InteropKind.Import && !type.IsInterface)
             return InspectInstance(type, InteropKind.Export, nul)!; // likely passing back an exported instance
         return InspectMembers(its[key] = new(type) {
@@ -82,7 +82,7 @@ internal sealed class TypeInspector
             Members = new List<MemberMeta>(),
             Exporter = ResolveExporter(),
             Importer = ResolveImporter(),
-        }, ik);
+        }, ik, nul);
 
         static bool IsInstanced (Type type)
         {
@@ -108,16 +108,16 @@ internal sealed class TypeInspector
         }
     }
 
-    private DelegateMeta InspectDelegate (Type type, InteropKind ik)
+    private DelegateMeta InspectDelegate (Type type, InteropKind ik, Nullity? nul)
     {
         var members = new List<MemberMeta>();
         var proxy = BuildProxy(type, BuildId(type), ik);
         var del = new DelegateMeta(type) { IK = ik, Proxy = proxy, Members = members };
-        members.Add(InspectMethod(type.GetMethod("Invoke")!, ik, del));
+        members.Add(InspectMethod(type.GetMethod("Invoke")!, ik, del, nul));
         return del;
     }
 
-    private T InspectMembers<T> (T surf, InteropKind ik) where T : ProxyMeta
+    private T InspectMembers<T> (T surf, InteropKind ik, Nullity? nul) where T : ProxyMeta
     {
         var members = (ICollection<MemberMeta>)surf.Members;
         var sp = surf.Proxy as SpecializedProxy;
@@ -129,7 +129,7 @@ internal sealed class TypeInspector
                 members.Add(InspectProperty(prop, ik, surf));
         foreach (var method in clr.GetMethods())
             if (ShouldInspectMethod(method))
-                members.Add(InspectMethod(method, ik, surf));
+                members.Add(InspectMethod(method, ik, surf, nul));
         return surf;
 
         bool ShouldInspectProperty (PropertyInfo prop)
@@ -170,34 +170,34 @@ internal sealed class TypeInspector
         Set = prop.SetMethod != null ? InspectValue(prop.PropertyType, GetNullity(prop), ik.Invert) : null
     };
 
-    private MethodMeta InspectMethod (MethodInfo method, InteropKind ik, SurfaceMeta srf) => new(method) {
+    private MethodMeta InspectMethod (MethodInfo meth, InteropKind ik, SurfaceMeta srf, Nullity? nul) => new(meth) {
         IK = ik,
         Surf = srf,
-        Name = BuildCSName(method.Name),
-        Endpoint = BuildCSName(method.Name),
-        JSName = BuildJSName(method.Name),
-        Args = method.GetParameters().Select(p => InspectArg(p, GetNullity(p), ik.Invert)).ToArray(),
-        Return = InspectValue(method.ReturnParameter.ParameterType, GetNullity(method.ReturnParameter), ik),
-        Void = IsVoid(method.ReturnParameter.ParameterType),
-        Async = IsTaskLike(method.ReturnParameter.ParameterType)
+        Name = BuildCSName(meth.Name),
+        Endpoint = BuildCSName(meth.Name),
+        JSName = BuildJSName(meth.Name),
+        Args = meth.GetParameters().Select(p => InspectArg(p, GetNullity(p, nul), ik.Invert)).ToArray(),
+        Return = InspectValue(meth.ReturnParameter.ParameterType, GetNullity(meth.ReturnParameter, nul), ik),
+        Void = IsVoid(meth.ReturnParameter.ParameterType),
+        Async = IsTaskLike(meth.ReturnParameter.ParameterType)
     };
 
-    private ArgumentMeta InspectArg (ParameterInfo param, NullabilityInfo nul, InteropKind ik) => new(param) {
+    private ArgumentMeta InspectArg (ParameterInfo param, Nullity nul, InteropKind ik) => new(param) {
         Name = BuildCSName(param.Name!),
         JSName = BuildJSName(param.Name!),
         Value = InspectValue(param.ParameterType, nul, ik)
     };
 
-    private ValueMeta InspectValue (Type type, NullabilityInfo nul, InteropKind ik) => new() {
+    private ValueMeta InspectValue (Type type, Nullity nul, InteropKind ik) => new() {
         Type = InspectType(type, ik, nul),
         TypeSyntax = BuildSyntax(type, nul),
         Nullable = IsNullable(type, nul)
     };
 
-    private TypeMeta InspectType (Type type, InteropKind ik, NullabilityInfo? nul = null)
+    private TypeMeta InspectType (Type type, InteropKind ik, Nullity? nul)
     {
-        CrawlInspected(type, ik);
-        return InspectInstance(type, ik, nul) ?? srd.Inspect(type, ik) ?? new TypeMeta(type);
+        CrawlInspected(type, ik, nul);
+        return InspectInstance(type, ik, nul) ?? srd.Inspect(type, ik, nul) ?? new TypeMeta(type);
     }
 
     private SurfaceProxy BuildProxy (Type type, string typeId, InteropKind ik, Specialization? sp = null)
@@ -210,18 +210,20 @@ internal sealed class TypeInspector
             Syntax = stx,
             Import = new(sp.For(type, InteropKind.Import)),
             Export = new(sp.For(type, InteropKind.Export)),
+            CS = sp.CS,
             JS = sp.JS,
+            JSCtor = sp.JSCtor,
             Decl = sp.Decl
         };
     }
 
-    private void CrawlInspected (Type type, InteropKind ik)
+    private void CrawlInspected (Type type, InteropKind ik, Nullity? nul)
     {
         for (var clr = type; clr.IsNested && IsUserType(clr.DeclaringType!); clr = clr.DeclaringType!)
             crawled.TryAdd(clr.DeclaringType!, new(clr.DeclaringType!));
         if (type.IsGenericMethodParameter)
             foreach (var compatible in FindCompatible(type))
-                InspectType(compatible, ik);
+                InspectType(compatible, ik, nul);
 
         static IEnumerable<Type> FindCompatible (Type param)
         {

--- a/src/cs/Bootsharp.Publish/Common/Preferences/Preferences.cs
+++ b/src/cs/Bootsharp.Publish/Common/Preferences/Preferences.cs
@@ -67,18 +67,19 @@ internal static class Preferences
 
     private static void ResolveSpecs (Assembly ass)
     {
-        var imports = new Dictionary<Type, (Type Type, string? JS, string? Decl)>();
+        var imports = new Dictionary<Type, (Type Type, string? CS, string? JS, string? JSCtor, string? Decl)>();
         var exports = new List<(Type Clr, Type Type)>();
         foreach (var type in ass.GetExportedTypes())
         foreach (var attr in type.CustomAttributes)
             if (IsAttribute<SpecializeImportAttribute>(attr))
-                imports[GetAttributeArg<Type>(attr)!] =
-                    (type, GetAttributeArg<string>(attr, 1), GetAttributeArg<string>(attr, 2));
+                imports[GetAttributeArg<Type>(attr)!] = (type,
+                    GetAttributeArg<string>(attr, 1), GetAttributeArg<string>(attr, 2),
+                    GetAttributeArg<string>(attr, 3), GetAttributeArg<string>(attr, 4));
             else if (IsAttribute<SpecializeExportAttribute>(attr))
                 exports.Add((GetAttributeArg<Type>(attr)!, type));
         foreach (var (clr, export) in exports)
-            prefs.Specs[clr] = imports.TryGetValue(clr, out var import)
-                ? new() { Import = import.Type, Export = export, JS = import.JS, Decl = import.Decl }
+            prefs.Specs[clr] = imports.TryGetValue(clr, out var i)
+                ? new() { Import = i.Type, Export = export, CS = i.CS, JS = i.JS, JSCtor = i.JSCtor, Decl = i.Decl }
                 : throw new Error($"Specialized export '{export.FullName}' is missing the paired import.");
     }
 

--- a/src/cs/Bootsharp.Publish/Common/Preferences/Specialization.cs
+++ b/src/cs/Bootsharp.Publish/Common/Preferences/Specialization.cs
@@ -4,7 +4,9 @@ internal sealed record Specialization
 {
     public required Type Import { get; init; }
     public required Type Export { get; init; }
+    public string? CS { get; init; }
     public string? JS { get; init; }
+    public string? JSCtor { get; init; }
     public string? Decl { get; init; }
 
     public Type For (Type specialized, InteropKind ik)

--- a/src/cs/Bootsharp.Publish/GenerateCS/CSInstanceGenerator.cs
+++ b/src/cs/Bootsharp.Publish/GenerateCS/CSInstanceGenerator.cs
@@ -98,7 +98,7 @@ internal sealed class CSInstanceGenerator
           {
               ~{{it.Proxy.Id}}() => Instances.DisposeImported(_id);
 
-              {{Fmt(it.Members.Select(EmitMemberImport))}}
+              {{Fmt([..it.Members.Select(EmitMemberImport), sp.CS])}}
           }
           """;
 

--- a/src/cs/Bootsharp.Publish/GenerateJS/Declarations/DeclarationGenerator.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/Declarations/DeclarationGenerator.cs
@@ -33,7 +33,7 @@ internal sealed class DeclarationGenerator
     }
 
     private string EmitImports (JSModule md) => Fmt([
-        $$"""import type { Event } from "{{md.To("bcl/event")}}";""",
+        $$"""import type * as $bcl from "{{md.To("bcl/index")}}";""",
         ..mds.GetImported(md).Select(imp =>
             $"""import type * as {imp.Alias} from "{md.ToMd(imp.Path)}";""")
     ], 0);
@@ -89,7 +89,7 @@ internal sealed class DeclarationGenerator
 
     private void DeclareDelegate (DelegateMeta del)
     {
-        doc.Type(del);
+        doc.Delegate(del);
         var inv = del.Invoker;
         var args = string.Join(", ", inv.Args.Select(a => $"{a.JSName}{ts.BuildArg(a.Info)}"));
         bld.Line($"export type {ts.BuildName(del.Clr)} = ({args}) => {ts.BuildReturn(inv.Info)};");
@@ -98,6 +98,11 @@ internal sealed class DeclarationGenerator
     private void DeclareInstance (InstanceMeta it)
     {
         doc.Type(it);
+        if (it.Proxy is SpecializedProxy { Decl: { } sp } && sp.StartsWith("export "))
+        {
+            bld.Line(sp);
+            return;
+        }
         bld.Enter($$"""export interface {{ts.BuildName(it.Clr)}}{{BuildExtensions()}} {""");
         foreach (var member in it.Members.Where(m => ShouldDeclareOn(it.Clr, m.Info)))
             if (member is EventMeta evt) DeclareEvent(evt);
@@ -118,7 +123,7 @@ internal sealed class DeclarationGenerator
         {
             doc.Event(evt);
             var args = string.Join(", ", evt.Args.Select(a => $"{a.JSName}{ts.BuildArg(evt.Info, a.Info)}"));
-            bld.Line($"{evt.JSName}: Event<[{args}]>;");
+            bld.Line($"{evt.JSName}: $bcl.Event<[{args}]>;");
         }
 
         void DeclareProperty (PropertyMeta prop)
@@ -147,7 +152,7 @@ internal sealed class DeclarationGenerator
         {
             doc.Event(evt);
             var args = string.Join(", ", evt.Args.Select(a => $"{a.JSName}{ts.BuildArg(evt.Info, a.Info)}"));
-            bld.Line($"export const {evt.JSName}: Event<[{args}]>;");
+            bld.Line($"export const {evt.JSName}: $bcl.Event<[{args}]>;");
         }
 
         void DeclareProperty (PropertyMeta prop)

--- a/src/cs/Bootsharp.Publish/GenerateJS/Declarations/DocumentationBuilder.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/Declarations/DocumentationBuilder.cs
@@ -29,6 +29,18 @@ internal sealed class DocumentationBuilder
             Append(GetSummary(xml));
     }
 
+    public void Delegate (DelegateMeta del)
+    {
+        var asm = del.Clr.Assembly.GetName().Name!;
+        var key = $"T:{GetXmlKey(del.Clr)}";
+        if (GetXml(asm, key) is not { } xml) return;
+        var sum = GetSummary(xml);
+        foreach (var arg in del.Invoker.Args)
+            if (GetArgXml(xml, arg) is { } x)
+                sum.Add($"@param {arg.JSName} {RenderXml(x)}");
+        Append(sum);
+    }
+
     public void Event (EventMeta evt)
     {
         var asm = evt.Info.DeclaringType!.Assembly.GetName().Name!;

--- a/src/cs/Bootsharp.Publish/GenerateJS/Declarations/TypeSyntaxBuilder.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/Declarations/TypeSyntaxBuilder.cs
@@ -70,7 +70,7 @@ internal sealed class TypeSyntaxBuilder (JSModules mds)
         return Build(prop.PropertyType, nul) + post;
     }
 
-    private string Build (Type type, NullabilityInfo? nul)
+    private string Build (Type type, Nullity? nul)
     {
         if (type.IsGenericTypeParameter) return type.Name;
         if (IsNullable(type, out var inner)) return Build(inner, EnterNullity(nul));
@@ -81,7 +81,7 @@ internal sealed class TypeSyntaxBuilder (JSModules mds)
         return BuildPrimitive(type);
     }
 
-    private string BuildTask (Type type, NullabilityInfo? nul)
+    private string BuildTask (Type type, Nullity? nul)
     {
         nul = EnterNullity(nul);
         var nil = IsNullable(nul) ? " | null" : "";
@@ -89,7 +89,7 @@ internal sealed class TypeSyntaxBuilder (JSModules mds)
         return $"Promise<{Build(result, nul)}{nil}>";
     }
 
-    private string BuildList (Type type, Type element, NullabilityInfo? nul)
+    private string BuildList (Type type, Type element, Nullity? nul)
     {
         nul = EnterNullity(nul);
         if (IsNullable(element, nul)) return $"Array<{Build(element, nul)} | null>";
@@ -108,14 +108,14 @@ internal sealed class TypeSyntaxBuilder (JSModules mds)
         };
     }
 
-    private string BuildDictionary (Type key, Type value, NullabilityInfo? nul)
+    private string BuildDictionary (Type key, Type value, Nullity? nul)
     {
         nul = EnterNullity(nul, 1);
         var nil = IsNullable(value, nul) ? " | null" : "";
         return $"Map<{Build(key, null)}, {Build(value, nul)}{nil}>";
     }
 
-    private string BuildUser (Type type, NullabilityInfo? nul)
+    private string BuildUser (Type type, Nullity? nul)
     {
         var @ref = mds.Ref(type, module);
         if (!type.IsGenericType) return @ref;
@@ -149,7 +149,7 @@ internal sealed class TypeSyntaxBuilder (JSModules mds)
         TypeCode.Byte or TypeCode.SByte or TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64 or
         TypeCode.Int16 or TypeCode.Int32 or TypeCode.Decimal or TypeCode.Double or TypeCode.Single;
 
-    private static NullabilityInfo? EnterNullity (NullabilityInfo? nul, int idx = 0)
+    private static Nullity? EnterNullity (Nullity? nul, int idx = 0)
     {
         if (nul == null) return null;
         if (nul.GenericTypeArguments.Length > idx) return nul.GenericTypeArguments[idx];

--- a/src/cs/Bootsharp.Publish/GenerateJS/JSInstanceGenerator.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/JSInstanceGenerator.cs
@@ -91,7 +91,11 @@ internal sealed class JSInstanceGenerator (bool debug, JSModules md)
         $$"""
           $i.{{it.Id}} = class {{it.Proxy.Id}} {
               {{Fmt([
-                  "constructor(_id) { this._id = _id; }",
+                  $$"""
+                    constructor(_id) {
+                        {{Fmt("this._id = _id;", sp.JSCtor)}}
+                    }
+                    """,
                   ..it.Members.Select(EmitMember),
                   sp.JS
               ])}}

--- a/src/cs/Bootsharp.Publish/GenerateJS/JSModuleGenerator.cs
+++ b/src/cs/Bootsharp.Publish/GenerateJS/JSModuleGenerator.cs
@@ -77,10 +77,7 @@ internal sealed class JSModuleGenerator (bool debug)
     {
         var name = $"broadcast{evt.Name}Serialized";
         var args = string.Join(", ", evt.Args.Select(a => a.JSName));
-        var invArgs = string.Join(", ", evt.Args.Select(arg =>
-            // By default, we use 'null' for missing collection items, but here the event args array
-            // represents args specified to the event's 'broadcast' function, so user expects 'undefined'.
-            $"{ExportJS(arg)}{(arg.Value.Nullable ? " ?? undefined" : "")}"));
+        var invArgs = string.Join(", ", evt.Args.Select(ExportJS));
         if (isIt)
         {
             var invName = $"$i.resolve(_id, $i.{it.Id}).broadcast{evt.Name}";

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.8.1-alpha.3</Version>
+        <Version>0.9.0-alpha.1</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.9.0-alpha.1</Version>
+        <Version>0.9.0-alpha.17</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>

--- a/src/cs/Directory.Build.props
+++ b/src/cs/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <Version>0.9.0-alpha.17</Version>
+        <Version>0.9.0-alpha.18</Version>
         <Authors>Elringus</Authors>
         <PackageTags>javascript typescript ts js wasm node deno bun interop codegen</PackageTags>
         <PackageProjectUrl>https://bootsharp.com</PackageProjectUrl>

--- a/src/js/test/cs/Test.Library/Modules/BidirectionalCS.cs
+++ b/src/js/test/cs/Test.Library/Modules/BidirectionalCS.cs
@@ -5,8 +5,15 @@ namespace Test.Library;
 public class BidirectionalCS : IBidirectional
 {
     public event Action<IBidirectional?>? OnBiChanged;
+    public Event<SpecialBiHandler> OnSpecial { get; } = new();
 
-    public IBidirectional? Bi { get; set => OnBiChanged?.Invoke(field = value); } = null!;
+    public IBidirectional? Bi { get; set => NotifyChanged(field = value); } = null!;
 
     public IBidirectional? EchoBi (IBidirectional? bi) => bi;
+
+    private void NotifyChanged (IBidirectional? bi)
+    {
+        OnBiChanged?.Invoke(bi);
+        OnSpecial.Broadcast(bi);
+    }
 }

--- a/src/js/test/cs/Test.Library/Modules/IBidirectional.cs
+++ b/src/js/test/cs/Test.Library/Modules/IBidirectional.cs
@@ -7,6 +7,7 @@ public interface IBidirectional
     event Action<IBidirectional?>? OnBiChanged;
 
     IBidirectional? Bi { get; set; }
+    Event<SpecialBiHandler> OnSpecial { get; }
 
     IBidirectional? EchoBi (IBidirectional? bi);
 }

--- a/src/js/test/cs/Test.Library/Modules/Modules.cs
+++ b/src/js/test/cs/Test.Library/Modules/Modules.cs
@@ -65,22 +65,29 @@ public static partial class Modules
     {
         var js = ImportBi();
         var cs = new BidirectionalCS();
-        IBidirectional? observed = null;
-        Action<IBidirectional?> handler = b => observed = b;
-        js.OnBiChanged += handler;
+        IBidirectional? eventObserved = null;
+        IBidirectional? specialObserved = null;
+        Action<IBidirectional?> eventHandler = b => eventObserved = b;
+        SpecialBiHandler specialHandler = b => specialObserved = b;
+        js.OnBiChanged += eventHandler;
+        js.OnSpecial.Subscribe(specialHandler);
         Assert(js.EchoBi(null) == null);
         Assert(js.EchoBi(js) == js);
         Assert(js.EchoBi(cs) == cs);
         js.Bi = cs;
-        Assert(observed == cs);
+        Assert(eventObserved == cs);
+        Assert(specialObserved == cs);
         Assert(js.Bi == cs);
         js.Bi = js;
-        Assert(observed == js);
+        Assert(eventObserved == js);
+        Assert(specialObserved == js);
         Assert(js.Bi == js);
         js.Bi = null;
-        Assert(observed == null);
+        Assert(eventObserved == null);
+        Assert(specialObserved == null);
         Assert(js.Bi == null);
-        js.OnBiChanged -= handler;
+        js.OnBiChanged -= eventHandler;
+        js.OnSpecial.Unsubscribe(specialHandler);
     }
 
     [Export]

--- a/src/js/test/cs/Test.Library/Specialization.cs
+++ b/src/js/test/cs/Test.Library/Specialization.cs
@@ -1,0 +1,101 @@
+﻿#pragma warning disable CA1050
+// Global namespace required for EventExtensions to be picked by the spliced CS.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Bootsharp;
+using Test.Library;
+
+[SpecializeImport(typeof(IComparer<>))]
+public abstract class ComparerImport<T> (int id) : SpecializedImport(id), IComparer<T>
+{
+    public abstract int Compare (T? x, T? y);
+}
+
+[SpecializeExport(typeof(IComparer<>))]
+public class ComparerExport<T> (IComparer<T> cmp) : SpecializedExport(cmp)
+{
+    public int Compare (T? x, T? y) => cmp.Compare(x, y);
+}
+
+public sealed class Event<T> where T : Delegate
+{
+    public List<T> Handlers { get; } = [];
+    public void Subscribe (T handler) => Handlers.Add(handler);
+    public void Unsubscribe (T handler) => Handlers.Remove(handler);
+}
+
+/// <summary>
+/// Specialized event handler.
+/// </summary>
+/// <param name="nul">Nul parameter doc.</param>
+/// <param name="str">Str parameter doc.</param>
+/// <param name="opt">Opt parameter doc.</param>
+public delegate void SpecialHandler (string? nul, string str, int? opt = null);
+
+public delegate void SpecialBiHandler (IBidirectional? bi);
+
+public static class EventExtensions
+{
+    extension (Event<SpecialHandler> @event)
+    {
+        public void Broadcast (string? nul, string str, int? opt = null)
+        {
+            foreach (var handler in @event.Handlers)
+                handler(nul, str, opt);
+        }
+    }
+
+    extension (Event<SpecialBiHandler> @event)
+    {
+        public void Broadcast (IBidirectional? bi)
+        {
+            foreach (var handler in @event.Handlers)
+                handler(bi);
+        }
+    }
+}
+
+[SpecializeImport(typeof(Event<>),
+    CS:
+    """
+    protected override object Unwrap () {
+        if (Event != null) return Event;
+        ImportedByEvent.Add(Event = new(), this);
+        Subscribe(Event.Broadcast);
+        return Event;
+    }
+    """,
+    JSCtor:
+    """
+    const event = new Event();
+    event._id = _id;
+    this.subscribe(event.broadcast.bind(event));
+    return event; 
+    """,
+    Decl:
+    """
+    export interface Event<T extends (...args: never[]) => void> {
+        readonly last?: Parameters<T>;
+        subscribe(handler: T): string;
+        unsubscribe(handler: T): void;
+        broadcast: T;
+    }
+    """)]
+public abstract class EventImport<T> (int id) : SpecializedImport(id) where T : Delegate
+{
+    protected internal static readonly ConditionalWeakTable<Event<T>, SpecializedImport> ImportedByEvent = new();
+    protected Event<T>? Event;
+
+    public abstract void Subscribe (T handler);
+}
+
+[SpecializeExport(typeof(Event<>))]
+public sealed class EventExport<T> (Event<T> evt) : SpecializedExport(Resolve(evt)) where T : Delegate
+{
+    public void Subscribe (T handler) => evt.Subscribe(handler);
+
+    private static object Resolve (Event<T> evt) =>
+        EventImport<T>.ImportedByEvent.TryGetValue(evt, out var imported) ? imported : evt;
+}

--- a/src/js/test/cs/Test.Library/Specialization.cs
+++ b/src/js/test/cs/Test.Library/Specialization.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CA1050
+#pragma warning disable CA1050
 // Global namespace required for EventExtensions to be picked by the spliced CS.
 
 using System;
@@ -72,7 +72,7 @@ public static class EventExtensions
     const event = new Event();
     event._id = _id;
     this.subscribe(event.broadcast.bind(event));
-    return event; 
+    return event;
     """,
     Decl:
     """

--- a/src/js/test/cs/Test.Library/Test.Library.csproj
+++ b/src/js/test/cs/Test.Library/Test.Library.csproj
@@ -6,6 +6,8 @@
         <CompilerGeneratedFilesOutputPath>bin/codegen</CompilerGeneratedFilesOutputPath>
         <Nullable>enable</Nullable>
         <DefineTrace>true</DefineTrace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/js/test/cs/Test/BCL.cs
+++ b/src/js/test/cs/Test/BCL.cs
@@ -172,22 +172,11 @@ public static partial class BCL
         Assert(cmp.Compare("a", "b") < 0);
         Assert(cmp.Compare("b", "a") > 0);
         Assert(cmp.Compare("a", "a") == 0);
+        Assert(cmp.Compare(null, null) == 0);
         Assert(new[] { "c", "a", "b" }.OrderBy(i => i, cmp).SequenceEqual(["a", "b", "c"]));
         var source = Comparer<string>.Create(string.CompareOrdinal);
         var echoed = EchoComparerImport(source);
         Assert(ReferenceEquals(source, echoed));
         Assert(ReferenceEquals(source, EchoComparerImport(echoed)));
     }
-}
-
-[SpecializeImport(typeof(IComparer<>))] // Testing user-specified specialization.
-public abstract class ComparerImport<T> (int id) : SpecializedImport(id), IComparer<T>
-{
-    public abstract int Compare (T? x, T? y);
-}
-
-[SpecializeExport(typeof(IComparer<>))]
-public class ComparerExport<T> (IComparer<T> cmp) : SpecializedExport(cmp)
-{
-    public int Compare (T? x, T? y) => cmp.Compare(x, y);
 }

--- a/src/js/test/cs/Test/Serialization.cs
+++ b/src/js/test/cs/Test/Serialization.cs
@@ -86,6 +86,8 @@ public static class Serialization
         Assert(biChanged != null);
         Assert(union.B?.GetChanged?.Invoke(new BidirectionalCS()) == null);
         union.A?.Changed?.Invoke(union.A, new Record("a-rec"));
+        union.A?.Changed?.Invoke(null, null);
         biChanged!.Invoke(bi, new Record("bi-rec"));
+        biChanged.Invoke(null, null);
     }
 }

--- a/src/js/test/cs/Test/Static.cs
+++ b/src/js/test/cs/Test/Static.cs
@@ -34,6 +34,8 @@ public static partial class Static
 
     [Import] public static partial string ImportedProperty { get; set; }
     [Export] public static string ExportedProperty { get; set; } = "initial exported";
+    [Import] public static partial Event<SpecialHandler> ImportedSpecial { get; }
+    [Export] public static Event<SpecialHandler> ExportedSpecial { get; } = new();
 
     [Import] public static partial byte[] EchoImported (byte[] bytes);
     [Export] public static byte[] EchoExported (byte[] bytes) => bytes;
@@ -43,6 +45,7 @@ public static partial class Static
     [Import] public static partial void ImportedFunction ();
     [Export] public static void InvokeImportedFunction () => ImportedFunction();
     [Export] public static void BroadcastExportedEvent (string? payload) => ExportedEvent?.Invoke(payload);
+    [Export] public static void BroadcastExportedSpecial (string? nul, string str, int? opt) => ExportedSpecial.Broadcast(nul, str, opt);
     [Export] public static DateTime AddDays (DateTime date, int days) => date.AddDays(days);
     [Export] public static Enum GetEnum (int idx) => (Enum)idx;
     [Export] public static T MakeGeneric<T> () where T : IShape, new() => new();
@@ -54,15 +57,20 @@ public static partial class Static
     [Export]
     public static async Task CanInteropWithImportedStaticsAsync ()
     {
-        var tcs = new TaskCompletionSource<string?>();
-        Action<string?> handler = v => tcs.TrySetResult(v);
-        ImportedEvent += handler;
+        var eventTcs = new TaskCompletionSource<string?>();
+        Action<string?> eventHandler = v => eventTcs.TrySetResult(v);
+        ImportedEvent += eventHandler;
+        var specialTcs = new TaskCompletionSource<(string?, string, int?)>();
+        SpecialHandler specialHandler = (nul, str, opt) => specialTcs.TrySetResult((nul, str, opt));
+        ImportedSpecial.Subscribe(specialHandler);
         Assert(ImportedProperty == "initial imported");
         ImportedProperty = "foo";
         Assert(ImportedProperty == "foo");
         Assert(EchoImported([42, 24]).Sum(i => i) == 66);
         Assert((await EchoImportedAsync([24, 42])).Sum(i => i) == 66);
-        Assert(await tcs.Task == "event payload");
-        ImportedEvent -= handler;
+        Assert(await eventTcs.Task == "event payload");
+        Assert(await specialTcs.Task == (null, "special payload", null));
+        ImportedEvent -= eventHandler;
+        ImportedSpecial.Unsubscribe(specialHandler);
     }
 }

--- a/src/js/test/spec/bcl.spec.ts
+++ b/src/js/test/spec/bcl.spec.ts
@@ -273,7 +273,7 @@ describe("BCL", () => {
             BCL.testDictionaryImport();
         });
     });
-    describe("user-specified specialization", () => {
+    describe("custom specializations", () => {
         const comparer = { compare: (x: string, y: string) => x < y ? -1 : x > y ? 1 : 0 };
         it("can interop with exported comparer", () => {
             const cmp = BCL.exportComparer();

--- a/src/js/test/spec/export.spec.ts
+++ b/src/js/test/spec/export.spec.ts
@@ -11,6 +11,9 @@ describe("export", () => {
         expect(bootsharp.dotnet.withConfig).toBeTypeOf("function");
     });
     it("exports documentation declarations", () => {
-        expect(getDeclarations()).toContain(`Sample class documentation.`);
+        const decls = getDeclarations();
+        expect(decls).toContain(" * Sample class documentation.");
+        expect(decls).toContain(" * Specialized event handler.");
+        expect(decls).toContain(" * @param nul Nul parameter doc.");
     });
 });

--- a/src/js/test/spec/interop.spec.ts
+++ b/src/js/test/spec/interop.spec.ts
@@ -30,9 +30,14 @@ class ImportedInner implements IImportedInnerInstanced {
 
 class BidirectionalJS implements IBidirectional {
     onBiChanged = new Event<[IBidirectional | undefined]>();
+    onSpecial = new Event<[IBidirectional | undefined]>();
     #bi?: IBidirectional;
     get bi() { return this.#bi; }
-    set bi(value) { this.onBiChanged.broadcast(this.#bi = value); }
+    set bi(value) {
+        this.#bi = value;
+        this.onBiChanged.broadcast(value);
+        this.onSpecial.broadcast(value);
+    }
     echoBi(bi?: IBidirectional) { return bi ?? null; }
 }
 
@@ -78,6 +83,8 @@ describe("while bootsharp is booted", () => {
     it("can interop with imported statics", async () => {
         let prop = "initial imported";
         Static.importedProperty = { get: () => prop, set: v => prop = v };
+        const importedSpecial = new Event<[string | undefined, string, number | undefined]>();
+        Static.importedSpecial = { get: () => importedSpecial };
         Static.echoImported = bytes => bytes;
         Static.echoImportedAsync = async bytes => {
             await new Promise(res => setTimeout(res, 1));
@@ -85,6 +92,7 @@ describe("while bootsharp is booted", () => {
         };
         const promise = Static.canInteropWithImportedStaticsAsync();
         Static.importedEvent.broadcast("event payload");
+        importedSpecial.broadcast(undefined, "special payload", undefined);
         await promise;
     });
     it("can interop with exported statics", async () => {
@@ -93,15 +101,25 @@ describe("while bootsharp is booted", () => {
         expect(Static.exportedProperty).toStrictEqual("initial exported");
         Static.exportedProperty = "set";
         expect(Static.exportedProperty).toStrictEqual("set");
-        const handler = vi.fn();
-        Static.exportedEvent.subscribe(handler);
+        const eventHandler = vi.fn();
+        Static.exportedEvent.subscribe(eventHandler);
         Static.broadcastExportedEvent("foo");
-        expect(handler).toHaveBeenCalledWith("foo");
+        expect(eventHandler).toHaveBeenCalledWith("foo");
         Static.broadcastExportedEvent(undefined);
-        expect(handler).toHaveBeenCalledWith(undefined);
-        Static.exportedEvent.unsubscribe(handler);
+        expect(eventHandler).toHaveBeenCalledWith(undefined);
+        Static.exportedEvent.unsubscribe(eventHandler);
         Static.broadcastExportedEvent("bar");
-        expect(handler).not.toHaveBeenCalledWith("bar");
+        expect(eventHandler).not.toHaveBeenCalledWith("bar");
+        const specialHandler = vi.fn();
+        expect(Static.exportedSpecial).toBe(Static.exportedSpecial);
+        Static.exportedSpecial.subscribe(specialHandler);
+        Static.broadcastExportedSpecial(undefined, "hello", 7);
+        expect(specialHandler).toHaveBeenCalledWith(undefined, "hello", 7);
+        expect(Static.exportedSpecial.last).toStrictEqual([undefined, "hello", 7]);
+        Static.exportedSpecial.unsubscribe(specialHandler);
+        Static.broadcastExportedSpecial(undefined, "bye", undefined);
+        expect(specialHandler).not.toHaveBeenCalledWith(undefined, "bye", undefined);
+        expect(Static.exportedSpecial.last).toStrictEqual([undefined, "bye", undefined]);
     });
     it("can interop with imported modules", async () => {
         let record: Record | undefined = { id: "initial" };
@@ -169,23 +187,33 @@ describe("while bootsharp is booted", () => {
         const factory = () => new BidirectionalJS();
         Modules.importBi = factory;
         expect(Modules.importBi).toBe(factory);
-        const exp = Modules.exportBi();
+        const cs = Modules.exportBi();
         const js = new BidirectionalJS();
-        const handler = vi.fn();
-        exp.onBiChanged.subscribe(handler);
-        expect(exp.echoBi(undefined)).toBe(null);
-        expect(exp.echoBi(exp)).toBe(exp);
-        expect(exp.echoBi(js)).toBe(js);
-        exp.bi = js;
-        expect(handler).toHaveBeenCalledWith(js);
-        expect(exp.bi).toBe(js);
-        exp.bi = exp;
-        expect(handler).toHaveBeenCalledWith(exp);
-        expect(exp.bi).toBe(exp);
-        exp.bi = undefined;
-        expect(handler).toHaveBeenCalledWith(undefined);
-        expect(exp.bi).toBe(undefined);
-        exp.onBiChanged.unsubscribe(handler);
+        const eventHandler = vi.fn();
+        const specialHandler = vi.fn();
+        cs.onBiChanged.subscribe(eventHandler);
+        expect(cs.onSpecial).toBe(cs.onSpecial);
+        cs.onSpecial.subscribe(specialHandler);
+        expect(cs.echoBi(undefined)).toBe(null);
+        expect(cs.echoBi(cs)).toBe(cs);
+        expect(cs.echoBi(js)).toBe(js);
+        cs.bi = js;
+        expect(eventHandler).toHaveBeenCalledWith(js);
+        expect(specialHandler).toHaveBeenCalledWith(js);
+        expect(cs.onSpecial.last).toStrictEqual([js]);
+        expect(cs.bi).toBe(js);
+        cs.bi = cs;
+        expect(eventHandler).toHaveBeenCalledWith(cs);
+        expect(specialHandler).toHaveBeenCalledWith(cs);
+        expect(cs.onSpecial.last).toStrictEqual([cs]);
+        expect(cs.bi).toBe(cs);
+        cs.bi = undefined;
+        expect(eventHandler).toHaveBeenCalledWith(undefined);
+        expect(specialHandler).toHaveBeenCalledWith(undefined);
+        expect(cs.onSpecial.last).toStrictEqual([undefined]);
+        expect(cs.bi).toBe(undefined);
+        cs.onBiChanged.unsubscribe(eventHandler);
+        cs.onSpecial.unsubscribe(specialHandler);
         Modules.canInteropWithBidirectional();
     });
     it("releases instances after use", async () => {


### PR DESCRIPTION
This adds `CS` and `JSCtor` parameters to `[SpecializeImport]` attribute, allowing to splice C# code into the generated C# proxy and JS code into the constructor of the generated JS proxy opening more ways to customize the specialized type behavior.

Also, when `Decl` start with `export ` it will now replace the entire TypeScript declaration instead of splicing the content at the bottom of the default declaration.

These features, along with several fixes allow advanced specialization scenarios, for example turning properties of specific type into events on the JS side: https://github.com/elringus/bootsharp/blob/c4feb0602fdf7a45fcbb70d6f43fa0e027629d13/src/js/test/cs/Test.Library/Specialization.cs#L60-L92

Documentation: https://bootsharp.com/guide/specialization#injecting-code
